### PR TITLE
feat(gl-003): idempotency key baseline for write operations

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,6 +1,11 @@
-import type { AuthenticatedUser, RequestContext } from "@grantledger/contracts";
+import type {
+  AuthenticatedUser,
+  IdempotencyRecord,
+  RequestContext,
+} from "@grantledger/contracts";
 import {
   hasActiveMembershipForTenant,
+  hashPayload,
   type Membership,
 } from "@grantledger/domain";
 
@@ -22,6 +27,20 @@ export class BadRequestError extends Error {
   constructor(message = "Invalid request input") {
     super(message);
     this.name = "BadRequestError";
+  }
+}
+
+export class MissingIdempotencyKeyError extends Error {
+  constructor(message = "Idempotency-Key is required") {
+    super(message);
+    this.name = "MissingIdempotencyKeyError";
+  }
+}
+
+export class IdempotencyConflictError extends Error {
+  constructor(message = "Idempotency key reuse with different payload") {
+    super(message);
+    this.name = "IdempotencyConflictError";
   }
 }
 
@@ -57,5 +76,56 @@ export function resolveRequestContext(
       id: membership.tenantId,
       role: membership.role,
     },
+  };
+}
+
+export interface ProcessWithIdempotencyInput<TPayload, TResponse> {
+  key: string | null;
+  payload: TPayload;
+  store: Map<string, IdempotencyRecord<TResponse>>;
+  execute: () => TResponse;
+  now?: () => Date;
+}
+
+export interface ProcessWithIdempotencyResult<TResponse> {
+  response: TResponse;
+  replayed: boolean;
+}
+
+export function processWithIdempotency<TPayload, TResponse>(
+  input: ProcessWithIdempotencyInput<TPayload, TResponse>,
+): ProcessWithIdempotencyResult<TResponse> {
+  if (!input.key) {
+    throw new MissingIdempotencyKeyError();
+  }
+
+  const payloadHash = hashPayload(input.payload);
+  const existingRecord = input.store.get(input.key);
+
+  if (existingRecord) {
+    if (existingRecord.payloadHash !== payloadHash) {
+      throw new IdempotencyConflictError();
+    }
+
+    return {
+      response: existingRecord.response,
+      replayed: true,
+    };
+  }
+
+  const response = input.execute();
+  const createdAt = (input.now ?? (() => new Date()))().toISOString();
+
+  input.store.set(input.key, {
+    key: input.key,
+    payloadHash,
+    status: "completed",
+    response,
+    createdAt,
+  });
+
+  return {
+    response,
+    replayed: false,
   };
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,3 +13,13 @@ export interface RequestContext {
   user: AuthenticatedUser;
   tenant: TenantContext;
 }
+
+export type IdempotencyStatus = "completed";
+
+export interface IdempotencyRecord<TResponse = unknown> {
+  key: string;
+  payloadHash: string;
+  status: IdempotencyStatus;
+  response: TResponse;
+  createdAt: string;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -15,8 +15,40 @@ export function hasActiveMembershipForTenant(
   const membership =
     memberships.find(
       (membershipItem) =>
-        membershipItem.tenantId === tenantId && membershipItem.status === "active",
+        membershipItem.tenantId === tenantId &&
+        membershipItem.status === "active",
     ) ?? null;
 
   return membership;
+}
+
+function stableSerialize(value: unknown): string {
+  if (typeof value === "undefined") {
+    return '"__undefined__"';
+  }
+
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item)).join(",")}]`;
+  }
+
+  const objectEntries = Object.entries(value as Record<string, unknown>).sort(
+    ([leftKey], [rightKey]) => leftKey.localeCompare(rightKey),
+  );
+
+  const serializedObject = objectEntries
+    .map(
+      ([entryKey, entryValue]) =>
+        `${JSON.stringify(entryKey)}:${stableSerialize(entryValue)}`,
+    )
+    .join(",");
+
+  return `{${serializedObject}}`;
+}
+
+export function hashPayload(payload: unknown): string {
+  return stableSerialize(payload);
 }


### PR DESCRIPTION
## Contexto
Implementa baseline de idempotência para operações de escrita, garantindo segurança contra reprocessamento em cenários de retry e duplicidade de requisição.

## Escopo
- Contratos compartilhados de idempotência em `packages/contracts`
  - `IdempotencyStatus`
  - `IdempotencyRecord`
- Hash estável de payload em `packages/domain`
  - `hashPayload(...)`
- Caso de uso em `packages/application`
  - `processWithIdempotency(...)`
  - `MissingIdempotencyKeyError`
  - `IdempotencyConflictError`
- Adapter mínimo em `apps/api`
  - `handleCreateSubscription(...)`
  - leitura do header `idempotency-key`
  - store in-memory para baseline

## Regras de negócio implementadas
1. sem `Idempotency-Key` => `400`
2. primeira requisição com chave nova => `201`
3. repetição com mesma chave + mesmo payload => `200` (replay)
4. mesma chave + payload diferente => `409`

## Validações executadas
- `npm run typecheck`
- `npm run build`
- `npm run lint`

## Resultado
GL-003 entrega o fundamento de idempotência para operações de escrita, com comportamento determinístico e pronto para evoluir para persistência distribuída.

Closes #<ISSUE_GL_003>