### PR TITLE
feat(gl-005): implement versioned plan catalog core with immutable plans versions

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -6,12 +6,173 @@ import type {
   BillingPeriod,
   CreateCheckoutSessionInput,
   CreateCheckoutSessionResult,
+  AuditActor,
+  CatalogAuditEvent,
+  CatalogQuery,
+  CreatePlanInput,
+  CreatePlanVersionInput,
+  DeactivatePlanVersionInput,
+  EffectiveCatalogItem,
+  Plan,
+  PlanVersion,
+  PublishPlanVersionInput,
 } from "@grantledger/contracts";
 import {
   hasActiveMembershipForTenant,
   hashPayload,
+  assertNoVersionOverlap,
+  assertPublishedVersionImmutable,
+  resolveEffectivePlanVersionAt,
   type Membership,
 } from "@grantledger/domain";
+
+export class ConflictError extends Error {}
+export class NotFoundError extends Error {}
+export class ValidationError extends Error {}
+
+export interface PlanCatalogRepository {
+  createPlan(input: CreatePlanInput): Promise<Plan>;
+  getPlanById(planId: string): Promise<Plan | null>;
+  listPlans(): Promise<Plan[]>;
+  createPlanVersion(input: CreatePlanVersionInput): Promise<PlanVersion>;
+  getPlanVersion(
+    planId: string,
+    versionId: string,
+  ): Promise<PlanVersion | null>;
+  listPlanVersions(planId: string): Promise<PlanVersion[]>;
+  savePlanVersion(planVersion: PlanVersion): Promise<void>;
+}
+
+export interface CatalogAuditLogger {
+  log(event: CatalogAuditEvent): Promise<void>;
+}
+
+interface AuditInput {
+  actor: AuditActor;
+  reason: string;
+  traceId: string;
+}
+
+export async function createPlan(
+  repo: PlanCatalogRepository,
+  audit: CatalogAuditLogger,
+  input: CreatePlanInput,
+  meta: AuditInput,
+): Promise<Plan> {
+  const plan = await repo.createPlan(input);
+  await audit.log({
+    event: "plan.created",
+    actor: meta.actor,
+    reason: meta.reason,
+    traceId: meta.traceId,
+    occurredAt: new Date().toISOString(),
+    metadata: { planId: plan.id },
+  });
+  return plan;
+}
+
+export async function createPlanVersion(
+  repo: PlanCatalogRepository,
+  audit: CatalogAuditLogger,
+  input: CreatePlanVersionInput,
+  meta: AuditInput,
+): Promise<PlanVersion> {
+  const versions = await repo.listPlanVersions(input.planId);
+
+  /* We need to check for overlapping validity windows before creating the version
+   otherwise we might end up with a published version that overlaps with the new one, which would
+   be a problem since published versions are immutable */
+  const candidate =
+    input.endsAt === undefined
+      ? { startsAt: input.startsAt }
+      : { startsAt: input.startsAt, endsAt: input.endsAt };
+
+  // This will throw if there's an overlap, which is what we want since we don't want to create the version in that case
+  assertNoVersionOverlap(candidate, versions);
+
+  const version = await repo.createPlanVersion(input);
+  await audit.log({
+    event: "plan_version.created",
+    actor: meta.actor,
+    reason: meta.reason,
+    traceId: meta.traceId,
+    occurredAt: new Date().toISOString(),
+    metadata: { planId: input.planId, versionId: version.id },
+  });
+  return version;
+}
+
+export async function publishPlanVersion(
+  repo: PlanCatalogRepository,
+  audit: CatalogAuditLogger,
+  input: PublishPlanVersionInput,
+  meta: AuditInput,
+): Promise<PlanVersion> {
+  const version = await repo.getPlanVersion(input.planId, input.versionId);
+  if (!version) throw new NotFoundError("Plan version not found");
+
+  const next: PlanVersion = {
+    ...version,
+    status: "published",
+    publishedAt: new Date().toISOString(),
+  };
+
+  await repo.savePlanVersion(next);
+  await audit.log({
+    event: "plan_version.published",
+    actor: meta.actor,
+    reason: meta.reason,
+    traceId: meta.traceId,
+    occurredAt: new Date().toISOString(),
+    metadata: { planId: input.planId, versionId: input.versionId },
+  });
+  return next;
+}
+
+export async function deactivatePlanVersion(
+  repo: PlanCatalogRepository,
+  audit: CatalogAuditLogger,
+  input: DeactivatePlanVersionInput,
+  meta: AuditInput,
+): Promise<PlanVersion> {
+  const version = await repo.getPlanVersion(input.planId, input.versionId);
+  if (!version) throw new NotFoundError("Plan version not found");
+
+  const next: PlanVersion = { ...version, status: "deactivated" };
+  await repo.savePlanVersion(next);
+  await audit.log({
+    event: "plan_version.deactivated",
+    actor: meta.actor,
+    reason: meta.reason,
+    traceId: meta.traceId,
+    occurredAt: new Date().toISOString(),
+    metadata: { planId: input.planId, versionId: input.versionId },
+  });
+  return next;
+}
+
+export async function getEffectiveCatalog(
+  repo: PlanCatalogRepository,
+  query: CatalogQuery,
+): Promise<EffectiveCatalogItem[]> {
+  const plans = await repo.listPlans();
+  const out: EffectiveCatalogItem[] = [];
+
+  for (const plan of plans) {
+    const versions = await repo.listPlanVersions(plan.id);
+    const effective = resolveEffectivePlanVersionAt(versions, query.at);
+    if (!effective) continue;
+    out.push({ plan, version: effective });
+  }
+
+  return out;
+}
+
+export async function assertVersionNotCriticalMutated(
+  current: PlanVersion,
+): Promise<void> {
+  assertPublishedVersionImmutable(current);
+}
 
 export class AuthenticationError extends Error {
   constructor(message = "User is not authenticated") {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -42,3 +42,86 @@ export interface CreateCheckoutSessionResult {
   checkoutUrl: string;
   createdAt: string;
 }
+
+export type CurrencyCode = "BRL" | "USD" | "EUR";
+export type BillingInterval = "month" | "year";
+
+export type PlanStatus = "active" | "inactive";
+export type PlanVersionStatus = "draft" | "published" | "deactivated";
+
+export interface Plan {
+  id: string;
+  code: string;
+  name: string;
+  status: PlanStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Price {
+  amountInCents: number;
+  currency: CurrencyCode;
+  billingInterval: BillingInterval;
+}
+
+export interface PlanVersion {
+  id: string;
+  planId: string;
+  version: number;
+  status: PlanVersionStatus;
+  price: Price;
+  startsAt: string;
+  endsAt?: string;
+  createdAt: string;
+  publishedAt?: string;
+}
+
+export interface CreatePlanInput {
+  code: string;
+  name: string;
+}
+
+export interface CreatePlanVersionInput {
+  planId: string;
+  price: Price;
+  startsAt: string;
+  endsAt?: string;
+}
+
+export interface PublishPlanVersionInput {
+  planId: string;
+  versionId: string;
+}
+
+export interface DeactivatePlanVersionInput {
+  planId: string;
+  versionId: string;
+}
+
+export interface CatalogQuery {
+  tenantId: string;
+  at: string;
+}
+
+export interface EffectiveCatalogItem {
+  plan: Plan;
+  version: PlanVersion;
+}
+
+export interface AuditActor {
+  id: string;
+  type: "user" | "service";
+}
+
+export interface CatalogAuditEvent {
+  event:
+    | "plan.created"
+    | "plan_version.created"
+    | "plan_version.published"
+    | "plan_version.deactivated";
+  actor: AuditActor;
+  reason: string;
+  traceId: string;
+  occurredAt: string;
+  metadata: Record<string, string>;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,3 +1,5 @@
+import type { PlanVersion } from "@grantledger/contracts";
+
 export type MembershipRole = "owner" | "admin" | "member";
 export type MembershipStatus = "active" | "inactive";
 
@@ -51,4 +53,57 @@ function stableSerialize(value: unknown): string {
 
 export function hashPayload(payload: unknown): string {
   return stableSerialize(payload);
+}
+
+function toTime(value: string): number {
+  return new Date(value).getTime();
+}
+
+function rangesOverlap(
+  aStart: string,
+  aEnd: string | undefined,
+  bStart: string,
+  bEnd: string | undefined,
+): boolean {
+  const aS = toTime(aStart);
+  const aE = aEnd ? toTime(aEnd) : Number.POSITIVE_INFINITY;
+  const bS = toTime(bStart);
+  const bE = bEnd ? toTime(bEnd) : Number.POSITIVE_INFINITY;
+  return aS <= bE && bS <= aE;
+}
+
+export function assertNoVersionOverlap(
+  candidate: Pick<PlanVersion, "startsAt" | "endsAt">,
+  existing: PlanVersion[],
+): void {
+  const hasOverlap = existing.some((v) =>
+    rangesOverlap(candidate.startsAt, candidate.endsAt, v.startsAt, v.endsAt),
+  );
+  if (hasOverlap)
+    throw new Error(
+      "Plan version validity window overlaps with an existing version",
+    );
+}
+
+export function assertPublishedVersionImmutable(current: PlanVersion): void {
+  if (current.status === "published")
+    throw new Error("Published plan version is immutable");
+}
+
+export function resolveEffectivePlanVersionAt(
+  versions: PlanVersion[],
+  at: string,
+): PlanVersion | null {
+  const point = toTime(at);
+  const valid = versions.filter((v) => {
+    if (v.status !== "published") return false;
+    const start = toTime(v.startsAt);
+    const end = v.endsAt ? toTime(v.endsAt) : Number.POSITIVE_INFINITY;
+    return point >= start && point <= end;
+  });
+
+  // If multiple versions are valid at the same time, we take the one with the most recent start date
+  const sorted = valid.sort((a, b) => toTime(b.startsAt) - toTime(a.startsAt));
+  const first = sorted[0];
+  return first ?? null; // explicitly return null if there are no valid versions
 }


### PR DESCRIPTION
## Context
Implements GL-005 by introducing a versioned, immutable plan catalog model for billing predictability and auditability.

## What was implemented
- Added core catalog contracts for `plan`, `plan_version`, and `price`
- Implemented domain rules for:
  - immutable published versions
  - validity overlap prevention
  - effective version resolution by timestamp
- Added application use cases for:
  - plan creation
  - plan version creation
  - version publish/deactivate
  - effective catalog read
- Added administrative audit event structure (`actor`, `reason`, `traceId`)

## Architectural notes
- `plan` is stable identity
- `plan_version` is the commercial state over time
- critical changes (price/validity) must produce a new version
- published versions are non-destructive

## Validation
- `npm run typecheck`
- `npm run build`
- `npm run lint`

## Out of scope
- subscription lifecycle (GL-006)
- invoice generation (GL-007)
- detailed entitlements (GL-009)

Closes #6
