### PR TITLE
feat(gl-006): implement subscription state machine with idempotent commands

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,28 +1,272 @@
 import {
   AuthenticationError,
   BadRequestError,
+  createSubscription,
   ForbiddenError,
   IdempotencyConflictError,
   MissingIdempotencyKeyError,
   processWithIdempotency,
   resolveRequestContext,
   startSubscriptionCheckout,
+  upgradeSubscription,
+  downgradeSubscription,
+  cancelSubscriptionNow,
+  cancelSubscriptionAtPeriodEnd,
+  SubscriptionNotFoundError,
+  SubscriptionValidationError,
+  SubscriptionConflictError,
+  SubscriptionIdempotencyConflictError,
+  type SubscriptionUseCaseDeps,
+  type SubscriptionRepository,
+  type SubscriptionIdempotencyStore,
+  type SubscriptionIdempotencyStoreRecord,
+  type SubscriptionEventPublisher,
+  type SubscriptionAuditLogger,
   type PaymentProvider,
 } from "@grantledger/application";
+
 import type {
   IdempotencyRecord,
   RequestContext,
   BillingPeriod,
   CreateCheckoutSessionInput,
   CreateCheckoutSessionResult,
+  Subscription,
+  SubscriptionDomainEvent,
+  SubscriptionAuditEvent,
+  CreateSubscriptionCommandInput,
+  UpgradeSubscriptionCommandInput,
+  DowngradeSubscriptionCommandInput,
+  CancelSubscriptionNowCommandInput,
+  CancelSubscriptionAtPeriodEndCommandInput,
 } from "@grantledger/contracts";
 import type { Membership } from "@grantledger/domain";
+import { randomUUID } from "crypto";
+import { SubscriptionDomainError } from "@grantledger/domain";
 
 type Headers = Record<string, string | undefined>;
-
 interface ApiResponse {
   status: number;
   body: unknown;
+}
+
+function GetHeaderGetHeader(headers: Headers, key: string): string | null {
+  return headers[key.toLowerCase()] ?? headers[key] ?? null;
+}
+
+class InMemorySubscriptionRepository implements SubscriptionRepository {
+  private readonly store = new Map<string, Subscription>();
+
+  async findById(subscriptionId: string): Promise<Subscription | null> {
+    return this.store.get(subscriptionId) ?? null;
+  }
+
+  // This method is not part of the SubscriptionRepository interface, but it's useful for testing purposes to directly add subscriptions to the store
+  async create(subscription: Subscription): Promise<void> {
+    this.store.set(subscription.id, subscription);
+  }
+
+  // This method update subscriptions in the store
+  async save(subscription: Subscription): Promise<void> {
+    this.store.set(subscription.id, subscription);
+  }
+}
+
+class InMemorySubscriptionIdempotencyStore implements SubscriptionIdempotencyStore {
+  private readonly store = new Map<
+    string,
+    SubscriptionIdempotencyStoreRecord
+  >();
+
+  async get(
+    command: string,
+    idempotencyKey: string,
+  ): Promise<SubscriptionIdempotencyStoreRecord | null> {
+    return this.store.get(`${command}:${idempotencyKey}`) ?? null;
+  }
+
+  async set(
+    command: string,
+    idempotencyKey: string,
+    record: SubscriptionIdempotencyStoreRecord,
+  ): Promise<void> {
+    this.store.set(`${command}:${idempotencyKey}`, record);
+  }
+}
+
+class ConsoleSubscriptionEventPublisher implements SubscriptionEventPublisher {
+  async publish(event: SubscriptionDomainEvent): Promise<void> {
+    console.log(JSON.stringify({ type: "domain_event", ...event }));
+  }
+}
+
+class ConsoleSubscriptionAuditLogger implements SubscriptionAuditLogger {
+  async log(event: SubscriptionAuditEvent): Promise<void> {
+    console.log(JSON.stringify({ type: "audit_event", ...event }));
+  }
+}
+
+const subscriptionDeps: SubscriptionUseCaseDeps = {
+  repository: new InMemorySubscriptionRepository(),
+  idempotencyStore: new InMemorySubscriptionIdempotencyStore(),
+  eventPublisher: new ConsoleSubscriptionEventPublisher(),
+  auditLogger: new ConsoleSubscriptionAuditLogger(),
+};
+
+function buildCommandContext(headers: Headers, reason: string) {
+  const actorId = GetHeaderGetHeader(headers, "x-user-id") ?? "system";
+  const traceId = GetHeaderGetHeader(headers, "x-trace-id") ?? randomUUID();
+  const idempotencyKey = GetHeaderGetHeader(headers, "idempotency-key") ?? "";
+  const requestedAt = new Date().toISOString();
+
+  return {
+    actor: { id: actorId, type: "user" as const },
+    reason,
+    traceId,
+    idempotencyKey,
+    requestedAt,
+  };
+}
+
+export async function handleCreateSubscriptionCommand(
+  headers: Headers,
+  payload: {
+    subscriptionId: string;
+    tenantId: string;
+    customerId: string;
+    planId: string;
+    currentPeriodStart: string;
+    currentPeriodEnd: string;
+    trialEndsAt?: string;
+    reason?: string;
+  },
+): Promise<ApiResponse> {
+  try {
+    const input: CreateSubscriptionCommandInput = {
+      subscriptionId: payload.subscriptionId,
+      tenantId: payload.tenantId,
+      customerId: payload.customerId,
+      planId: payload.planId,
+      currentPeriod: {
+        startsAt: payload.currentPeriodStart,
+        endsAt: payload.currentPeriodEnd,
+      },
+      ...(payload.trialEndsAt !== undefined
+        ? { trialEndsAt: payload.trialEndsAt }
+        : {}),
+      context: buildCommandContext(
+        headers,
+        payload.reason ?? "create subscription",
+      ),
+    };
+
+    const result = await createSubscription(subscriptionDeps, input);
+    return { status: 201, body: result };
+  } catch (error) {
+    return toApiError(error);
+  }
+}
+
+export async function handleUpgradeSubscriptionCommand(
+  headers: Headers,
+  payload: {
+    subscriptionId: string;
+    nextPlanId: string;
+    effectiveAt: string;
+    reason?: string;
+  },
+): Promise<ApiResponse> {
+  try {
+    const input: UpgradeSubscriptionCommandInput = {
+      subscriptionId: payload.subscriptionId,
+      nextPlanId: payload.nextPlanId,
+      effectiveAt: payload.effectiveAt,
+      context: buildCommandContext(
+        headers,
+        payload.reason ?? "upgrade subscription",
+      ),
+    };
+
+    const result = await upgradeSubscription(subscriptionDeps, input);
+    return { status: 200, body: result };
+  } catch (error) {
+    return toApiError(error);
+  }
+}
+
+export async function handleDowngradeSubscriptionCommand(
+  headers: Headers,
+  payload: {
+    subscriptionId: string;
+    nextPlanId: string;
+    effectiveAt: string;
+    reason?: string;
+  },
+): Promise<ApiResponse> {
+  try {
+    const input: DowngradeSubscriptionCommandInput = {
+      subscriptionId: payload.subscriptionId,
+      nextPlanId: payload.nextPlanId,
+      effectiveAt: payload.effectiveAt,
+      context: buildCommandContext(
+        headers,
+        payload.reason ?? "downgrade subscription",
+      ),
+    };
+
+    const result = await downgradeSubscription(subscriptionDeps, input);
+    return { status: 200, body: result };
+  } catch (error) {
+    return toApiError(error);
+  }
+}
+
+export async function handleCancelSubscriptionNowCommand(
+  headers: Headers,
+  payload: {
+    subscriptionId: string;
+    canceledAt: string;
+    reason?: string;
+  },
+): Promise<ApiResponse> {
+  try {
+    const input: CancelSubscriptionNowCommandInput = {
+      subscriptionId: payload.subscriptionId,
+      canceledAt: payload.canceledAt,
+      context: buildCommandContext(
+        headers,
+        payload.reason ?? "cancel subscription now",
+      ),
+    };
+
+    const result = await cancelSubscriptionNow(subscriptionDeps, input);
+    return { status: 200, body: result };
+  } catch (error) {
+    return toApiError(error);
+  }
+}
+
+export async function handleCancelSubscriptionAtPeriodEndCommand(
+  headers: Headers,
+  payload: {
+    subscriptionId: string;
+    reason?: string;
+  },
+): Promise<ApiResponse> {
+  try {
+    const input: CancelSubscriptionAtPeriodEndCommandInput = {
+      subscriptionId: payload.subscriptionId,
+      context: buildCommandContext(
+        headers,
+        payload.reason ?? "cancel subscription at period end",
+      ),
+    };
+
+    const result = await cancelSubscriptionAtPeriodEnd(subscriptionDeps, input);
+    return { status: 200, body: result };
+  } catch (error) {
+    return toApiError(error);
+  }
 }
 
 interface CreateSubscriptionPayload {
@@ -188,15 +432,16 @@ class FakePaymentProvider implements PaymentProvider {
   }
 }
 
+// Simple implementation that generates fake checkout session data for demonstration purposes.
 const fakePaymentProvider = new FakePaymentProvider();
 
+// This handler demonstrates how to start a subscription checkout session using the startSubscriptionCheckout use case from the application layer. It resolves the request context from the headers, validates the input payload, and calls the use case with the appropriate dependencies and parameters. It also handles various error scenarios and returns appropriate HTTP status codes and messages in the API response.
 export async function handleStartCheckout(
   headers: Headers,
   payload: StartCheckoutPayload,
 ): Promise<ApiResponse> {
   try {
     const context = resolveContextFromHeaders(headers);
-
     const checkout = await startSubscriptionCheckout({
       provider: fakePaymentProvider,
       tenantId: context.tenant.id,
@@ -204,15 +449,18 @@ export async function handleStartCheckout(
       billingPeriod: payload.billingPeriod,
       ...(payload?.successUrl !== undefined
         ? { successUrl: payload.successUrl }
-        : {}),
+        : {}), // The successUrl is where the user will be redirected after a successful payment, and the cancelUrl is where they will be redirected if they cancel the checkout process. These URLs are typically provided by the client application to ensure that the user is returned to the appropriate page after completing or canceling the checkout process.
+
       ...(payload?.cancelUrl !== undefined
         ? { cancelUrl: payload.cancelUrl }
-        : {}),
+        : {}), // The cancelUrl is where the user will be redirected if they cancel the checkout process, and the successUrl is where they will be redirected after a successful payment. These URLs are typically provided by the client application to ensure that the user is returned to the appropriate page after completing or canceling the checkout process.
+
       ...(payload?.externalReference !== undefined
         ? { externalReference: payload.externalReference }
-        : {}),
+        : {}), // The externalReference is an optional field that can be used to associate the checkout session with an external system or reference, such as an order ID or user ID from the client application. This can be useful for tracking and reconciliation purposes when handling webhook events from the payment provider about the checkout session status (e.g., completed, canceled, etc.).
     });
 
+    // You would also want to persist the checkout session details in your database and associate it with the tenant and plan for later reference when handling webhook events from the payment provider about the checkout session status (e.g., completed, canceled, etc.). For this example, we are simply returning the checkout session details in the API response.
     return {
       status: 201,
       body: {
@@ -223,17 +471,55 @@ export async function handleStartCheckout(
     };
   } catch (error) {
     if (error instanceof AuthenticationError) {
+      // AuthenticationError can be thrown if the user is not authenticated, so we return a 401 Unauthorized response with the error message to indicate that the client needs to authenticate before making this request.
       return { status: 401, body: { message: error.message } };
     }
 
     if (error instanceof ForbiddenError) {
+      // ForbiddenError can be thrown if the user does not have permission to start a checkout session for the specified plan or tenant, so we return a 403 Forbidden response with the error message to indicate that the client is authenticated but does not have the necessary permissions to perform this action.
       return { status: 403, body: { message: error.message } };
     }
 
     if (error instanceof BadRequestError) {
+      // BadRequestError can be thrown for various reasons, such as invalid input data or unsupported billing periods, so we return a 400 Bad Request response with the error message to provide more context to the client about what went wrong with their request.
       return { status: 400, body: { message: error.message } };
     }
 
+    // For any other unhandled errors, we return a generic 500 Internal Server Error response
     return { status: 500, body: { message: "Unexpected error" } };
   }
+}
+
+// Helper function to convert application errors to API responses
+function getErrorMessage(error: unknown): string {
+  // This function checks if the error is an instance of the built-in Error class and returns its message property. If the error is not an instance of Error, it returns a generic "Unknown error" message. This is useful for ensuring that we always return a string message in our API responses, even if the error object does not conform to the standard Error structure.
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+// This function maps application errors to appropriate HTTP status codes and response bodies
+function toApiError(error: unknown): {
+  status: number;
+  body: { message: string };
+} {
+  if (error instanceof SubscriptionValidationError) {
+    /// This is an example of a domain-specific error that could occur during subscription operations
+    return { status: 400, body: { message: getErrorMessage(error) } };
+  }
+
+  if (error instanceof SubscriptionNotFoundError) {
+    // This error indicates that a subscription with the specified ID was not found in the system
+    return { status: 404, body: { message: getErrorMessage(error) } };
+  }
+
+  if (
+    error instanceof SubscriptionConflictError ||
+    error instanceof SubscriptionIdempotencyConflictError ||
+    error instanceof SubscriptionDomainError
+  ) {
+    // These errors indicate various types of conflicts that can occur during subscription operations, such as trying to create a subscription that already exists or performing an action that is not allowed in the current state of the subscription
+    return { status: 409, body: { message: getErrorMessage(error) } };
+  }
+
+  // For any other unhandled errors, we return a generic 500 Internal Server Error response
+  return { status: 500, body: { message: "Unexpected error" } };
 }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -344,3 +344,304 @@ export async function startSubscriptionCheckout(
 
   return input.provider.createCheckoutSession(checkoutInput);
 }
+
+import type {
+  CancelSubscriptionAtPeriodEndCommandInput,
+  CancelSubscriptionNowCommandInput,
+  CreateSubscriptionCommandInput,
+  DowngradeSubscriptionCommandInput,
+  Subscription,
+  SubscriptionAuditEvent,
+  SubscriptionCommandContext,
+  SubscriptionDomainEvent,
+  UpgradeSubscriptionCommandInput,
+} from "@grantledger/contracts";
+import {
+  applyCancelAtPeriodEnd,
+  applyCancelNow,
+  applyDowngrade,
+  applyUpgrade,
+  createSubscriptionAggregate,
+} from "@grantledger/domain";
+
+export class SubscriptionNotFoundError extends Error {}
+export class SubscriptionValidationError extends Error {}
+export class SubscriptionIdempotencyConflictError extends Error {}
+export class SubscriptionConflictError extends Error {}
+
+export interface SubscriptionRepository {
+  findById(subscriptionId: string): Promise<Subscription | null>;
+  create(subscription: Subscription): Promise<void>;
+  save(subscription: Subscription): Promise<void>;
+}
+
+export interface SubscriptionEventPublisher {
+  publish(event: SubscriptionDomainEvent): Promise<void>;
+}
+
+export interface SubscriptionAuditLogger {
+  log(event: SubscriptionAuditEvent): Promise<void>;
+}
+
+export interface SubscriptionIdempotencyStoreRecord {
+  fingerprint: string;
+  response: Subscription;
+}
+
+export interface SubscriptionIdempotencyStore {
+  get(
+    command: string,
+    idempotencyKey: string,
+  ): Promise<SubscriptionIdempotencyStoreRecord | null>;
+  set(
+    command: string,
+    idempotencyKey: string,
+    record: SubscriptionIdempotencyStoreRecord,
+  ): Promise<void>;
+}
+
+export interface SubscriptionUseCaseDeps {
+  repository: SubscriptionRepository;
+  eventPublisher: SubscriptionEventPublisher;
+  auditLogger: SubscriptionAuditLogger;
+  idempotencyStore: SubscriptionIdempotencyStore;
+}
+
+function fingerprint(payload: unknown): string {
+  return JSON.stringify(payload);
+}
+
+function requireIdempotencyKey(context: SubscriptionCommandContext): void {
+  if (!context.idempotencyKey || context.idempotencyKey.trim().length === 0) {
+    throw new SubscriptionValidationError("idempotencyKey is required");
+  }
+}
+
+async function runIdempotentCommand(
+  deps: SubscriptionUseCaseDeps,
+  command: string,
+  context: SubscriptionCommandContext,
+  payloadForFingerprint: unknown,
+  execute: () => Promise<Subscription>,
+): Promise<Subscription> {
+  requireIdempotencyKey(context);
+
+  const fp = fingerprint(payloadForFingerprint);
+  const existing = await deps.idempotencyStore.get(
+    command,
+    context.idempotencyKey,
+  );
+
+  if (existing) {
+    if (existing.fingerprint !== fp) {
+      throw new SubscriptionIdempotencyConflictError(
+        "Same idempotency key with different payload",
+      );
+    }
+    return existing.response;
+  }
+
+  const response = await execute();
+  await deps.idempotencyStore.set(command, context.idempotencyKey, {
+    fingerprint: fp,
+    response,
+  });
+
+  return response;
+}
+
+async function audit(
+  deps: SubscriptionUseCaseDeps,
+  event: SubscriptionAuditEvent,
+): Promise<void> {
+  await deps.auditLogger.log(event);
+}
+
+export async function createSubscription(
+  deps: SubscriptionUseCaseDeps,
+  input: CreateSubscriptionCommandInput,
+): Promise<Subscription> {
+  return runIdempotentCommand(
+    deps,
+    "create_subscription",
+    input.context,
+    input,
+    async () => {
+      const existing = await deps.repository.findById(input.subscriptionId);
+      if (existing) {
+        throw new SubscriptionConflictError("Subscription already exists");
+      }
+
+      // The aggregate will perform all necessary validations in the constructor and throw if something is wrong with the input, which will prevent us from creating the subscription or publishing the event if the input is invalid
+      const result = createSubscriptionAggregate({
+        subscriptionId: input.subscriptionId,
+        tenantId: input.tenantId,
+        customerId: input.customerId,
+        planId: input.planId,
+        currentPeriod: input.currentPeriod,
+        ...(input.trialEndsAt !== undefined
+          ? { trialEndsAt: input.trialEndsAt }
+          : {}), // trialEndsAt is optional, so we only include it if it's defined
+        occurredAt: input.context.requestedAt,
+      });
+
+      // We need to create the subscription before publishing the event to ensure that the subscription exists when the event is processed, otherwise we might end up with an event that references a non-existent subscription if the event is processed before the subscription is created
+      await deps.repository.create(result.next);
+      await deps.eventPublisher.publish(result.event);
+      await audit(deps, {
+        action: "subscription.create",
+        actor: input.context.actor,
+        reason: input.context.reason,
+        traceId: input.context.traceId,
+        occurredAt: input.context.requestedAt,
+        subscriptionId: result.next.id,
+        tenantId: result.next.tenantId,
+        metadata: { status: result.next.status, planId: result.next.planId },
+      });
+
+      return result.next;
+    },
+  );
+}
+
+export async function upgradeSubscription(
+  deps: SubscriptionUseCaseDeps,
+  input: UpgradeSubscriptionCommandInput,
+): Promise<Subscription> {
+  return runIdempotentCommand(
+    deps,
+    "upgrade_subscription",
+    input.context,
+    input,
+    async () => {
+      const current = await deps.repository.findById(input.subscriptionId);
+      if (!current)
+        throw new SubscriptionNotFoundError("Subscription not found");
+
+      const result = applyUpgrade(current, input.nextPlanId, input.effectiveAt);
+      await deps.repository.save(result.next);
+      await deps.eventPublisher.publish(result.event);
+      await audit(deps, {
+        action: "subscription.upgrade",
+        actor: input.context.actor,
+        reason: input.context.reason,
+        traceId: input.context.traceId,
+        occurredAt: input.context.requestedAt,
+        subscriptionId: result.next.id,
+        tenantId: result.next.tenantId,
+        metadata: {
+          nextPlanId: input.nextPlanId,
+          effectiveAt: input.effectiveAt,
+        },
+      });
+
+      return result.next;
+    },
+  );
+}
+
+export async function downgradeSubscription(
+  deps: SubscriptionUseCaseDeps,
+  input: DowngradeSubscriptionCommandInput,
+): Promise<Subscription> {
+  return runIdempotentCommand(
+    deps,
+    "downgrade_subscription",
+    input.context,
+    input,
+    async () => {
+      const current = await deps.repository.findById(input.subscriptionId);
+      if (!current)
+        throw new SubscriptionNotFoundError("Subscription not found");
+
+      const result = applyDowngrade(
+        current,
+        input.nextPlanId,
+        input.effectiveAt,
+      );
+      await deps.repository.save(result.next);
+      await deps.eventPublisher.publish(result.event);
+      await audit(deps, {
+        action: "subscription.downgrade",
+        actor: input.context.actor,
+        reason: input.context.reason,
+        traceId: input.context.traceId,
+        occurredAt: input.context.requestedAt,
+        subscriptionId: result.next.id,
+        tenantId: result.next.tenantId,
+        metadata: {
+          nextPlanId: input.nextPlanId,
+          effectiveAt: input.effectiveAt,
+        },
+      });
+
+      return result.next;
+    },
+  );
+}
+
+export async function cancelSubscriptionNow(
+  deps: SubscriptionUseCaseDeps,
+  input: CancelSubscriptionNowCommandInput,
+): Promise<Subscription> {
+  return runIdempotentCommand(
+    deps,
+    "cancel_subscription_now",
+    input.context,
+    input,
+    async () => {
+      const current = await deps.repository.findById(input.subscriptionId);
+      if (!current)
+        throw new SubscriptionNotFoundError("Subscription not found");
+
+      const result = applyCancelNow(current, input.canceledAt);
+      await deps.repository.save(result.next);
+      await deps.eventPublisher.publish(result.event);
+      await audit(deps, {
+        action: "subscription.cancel_now",
+        actor: input.context.actor,
+        reason: input.context.reason,
+        traceId: input.context.traceId,
+        occurredAt: input.context.requestedAt,
+        subscriptionId: result.next.id,
+        tenantId: result.next.tenantId,
+        metadata: { canceledAt: input.canceledAt },
+      });
+
+      return result.next;
+    },
+  );
+}
+
+export async function cancelSubscriptionAtPeriodEnd(
+  deps: SubscriptionUseCaseDeps,
+  input: CancelSubscriptionAtPeriodEndCommandInput,
+): Promise<Subscription> {
+  return runIdempotentCommand(
+    deps,
+    "cancel_subscription_at_period_end",
+    input.context,
+    input,
+    async () => {
+      const current = await deps.repository.findById(input.subscriptionId);
+      if (!current)
+        throw new SubscriptionNotFoundError("Subscription not found");
+
+      const result = applyCancelAtPeriodEnd(current, input.context.requestedAt);
+      await deps.repository.save(result.next);
+      await deps.eventPublisher.publish(result.event);
+      await audit(deps, {
+        action: "subscription.cancel_at_period_end",
+        actor: input.context.actor,
+        reason: input.context.reason,
+        traceId: input.context.traceId,
+        occurredAt: input.context.requestedAt,
+        subscriptionId: result.next.id,
+        tenantId: result.next.tenantId,
+        metadata: { periodEndsAt: result.next.currentPeriod.endsAt },
+      });
+
+      return result.next;
+    },
+  );
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -125,3 +125,103 @@ export interface CatalogAuditEvent {
   occurredAt: string;
   metadata: Record<string, string>;
 }
+
+// GL-006 - Subscriptions state machine contracts
+
+export type SubscriptionStatus =
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled";
+
+export interface SubscriptionPeriod {
+  startsAt: string;
+  endsAt: string;
+}
+
+export interface Subscription {
+  id: string;
+  tenantId: string;
+  customerId: string;
+  planId: string;
+  status: SubscriptionStatus;
+  currentPeriod: SubscriptionPeriod;
+  cancelAtPeriodEnd: boolean;
+  canceledAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SubscriptionCommandContext {
+  actor: AuditActor;
+  reason: string;
+  traceId: string;
+  requestedAt: string;
+  idempotencyKey: string;
+}
+
+export interface CreateSubscriptionCommandInput {
+  subscriptionId: string;
+  tenantId: string;
+  customerId: string;
+  planId: string;
+  currentPeriod: SubscriptionPeriod;
+  trialEndsAt?: string;
+  context: SubscriptionCommandContext;
+}
+
+export interface UpgradeSubscriptionCommandInput {
+  subscriptionId: string;
+  nextPlanId: string;
+  effectiveAt: string;
+  context: SubscriptionCommandContext;
+}
+
+export interface DowngradeSubscriptionCommandInput {
+  subscriptionId: string;
+  nextPlanId: string;
+  effectiveAt: string;
+  context: SubscriptionCommandContext;
+}
+
+export interface CancelSubscriptionNowCommandInput {
+  subscriptionId: string;
+  canceledAt: string;
+  context: SubscriptionCommandContext;
+}
+
+export interface CancelSubscriptionAtPeriodEndCommandInput {
+  subscriptionId: string;
+  context: SubscriptionCommandContext;
+}
+
+export type SubscriptionDomainEventName =
+  | "subscription.created"
+  | "subscription.upgraded"
+  | "subscription.downgraded"
+  | "subscription.canceled_now"
+  | "subscription.cancel_at_period_end";
+
+export interface SubscriptionDomainEvent {
+  name: SubscriptionDomainEventName;
+  subscriptionId: string;
+  tenantId: string;
+  occurredAt: string;
+  payload: Record<string, string>;
+}
+
+export interface SubscriptionAuditEvent {
+  action:
+    | "subscription.create"
+    | "subscription.upgrade"
+    | "subscription.downgrade"
+    | "subscription.cancel_now"
+    | "subscription.cancel_at_period_end";
+  actor: AuditActor;
+  reason: string;
+  traceId: string;
+  occurredAt: string;
+  subscriptionId: string;
+  tenantId: string;
+  metadata: Record<string, string>;
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -107,3 +107,211 @@ export function resolveEffectivePlanVersionAt(
   const first = sorted[0];
   return first ?? null; // explicitly return null if there are no valid versions
 }
+
+import type {
+  Subscription,
+  SubscriptionDomainEvent,
+  SubscriptionStatus,
+} from "@grantledger/contracts";
+
+const ALLOWED_STATUS_TRANSITIONS: Record<
+  SubscriptionStatus,
+  SubscriptionStatus[]
+> = {
+  trialing: ["active", "past_due", "canceled"],
+  active: ["past_due", "canceled"],
+  past_due: ["active", "canceled"],
+  canceled: [],
+};
+
+function toEpoch(value: string): number {
+  return new Date(value).getTime();
+}
+
+function assertInCurrentPeriod(subscription: Subscription, at: string): void {
+  const now = toEpoch(at);
+  const start = toEpoch(subscription.currentPeriod.startsAt);
+  const end = toEpoch(subscription.currentPeriod.endsAt);
+
+  if (now < start || now > end) {
+    throw new SubscriptionDomainError(
+      "effectiveAt must be within current billing period",
+    );
+  }
+}
+
+export class SubscriptionDomainError extends Error {}
+export class InvalidSubscriptionTransitionError extends SubscriptionDomainError {}
+
+export function assertTransitionAllowed(
+  from: SubscriptionStatus,
+  to: SubscriptionStatus,
+): void {
+  if (!ALLOWED_STATUS_TRANSITIONS[from].includes(to)) {
+    throw new InvalidSubscriptionTransitionError(
+      `Invalid transition from ${from} to ${to}`,
+    );
+  }
+}
+
+export function createSubscriptionAggregate(input: {
+  subscriptionId: string;
+  tenantId: string;
+  customerId: string;
+  planId: string;
+  currentPeriod: { startsAt: string; endsAt: string };
+  trialEndsAt?: string;
+  occurredAt: string;
+}): { next: Subscription; event: SubscriptionDomainEvent } {
+  const status: SubscriptionStatus = input.trialEndsAt ? "trialing" : "active";
+
+  const next: Subscription = {
+    id: input.subscriptionId,
+    tenantId: input.tenantId,
+    customerId: input.customerId,
+    planId: input.planId,
+    status,
+    currentPeriod: input.currentPeriod,
+    cancelAtPeriodEnd: false,
+    createdAt: input.occurredAt,
+    updatedAt: input.occurredAt,
+  };
+
+  const event: SubscriptionDomainEvent = {
+    name: "subscription.created",
+    subscriptionId: next.id,
+    tenantId: next.tenantId,
+    occurredAt: input.occurredAt,
+    payload: {
+      status: next.status,
+      planId: next.planId,
+    },
+  };
+
+  return { next, event };
+}
+
+export function applyUpgrade(
+  current: Subscription,
+  nextPlanId: string,
+  effectiveAt: string,
+): { next: Subscription; event: SubscriptionDomainEvent } {
+  if (current.status === "canceled") {
+    throw new SubscriptionDomainError(
+      "Canceled subscription cannot be upgraded",
+    );
+  }
+
+  assertInCurrentPeriod(current, effectiveAt);
+
+  const next: Subscription = {
+    ...current,
+    planId: nextPlanId,
+    updatedAt: effectiveAt,
+  };
+
+  const event: SubscriptionDomainEvent = {
+    name: "subscription.upgraded",
+    subscriptionId: next.id,
+    tenantId: next.tenantId,
+    occurredAt: effectiveAt,
+    payload: {
+      previousPlanId: current.planId,
+      nextPlanId,
+    },
+  };
+
+  return { next, event };
+}
+
+export function applyDowngrade(
+  current: Subscription,
+  nextPlanId: string,
+  effectiveAt: string,
+): { next: Subscription; event: SubscriptionDomainEvent } {
+  if (current.status === "canceled") {
+    throw new SubscriptionDomainError(
+      "Canceled subscription cannot be downgraded",
+    );
+  }
+
+  assertInCurrentPeriod(current, effectiveAt);
+
+  const next: Subscription = {
+    ...current,
+    planId: nextPlanId,
+    updatedAt: effectiveAt,
+  };
+
+  const event: SubscriptionDomainEvent = {
+    name: "subscription.downgraded",
+    subscriptionId: next.id,
+    tenantId: next.tenantId,
+    occurredAt: effectiveAt,
+    payload: {
+      previousPlanId: current.planId,
+      nextPlanId,
+    },
+  };
+
+  return { next, event };
+}
+
+export function applyCancelNow(
+  current: Subscription,
+  canceledAt: string,
+): { next: Subscription; event: SubscriptionDomainEvent } {
+  assertTransitionAllowed(current.status, "canceled");
+
+  const next: Subscription = {
+    ...current,
+    status: "canceled",
+    cancelAtPeriodEnd: false,
+    canceledAt,
+    currentPeriod: {
+      ...current.currentPeriod,
+      endsAt: canceledAt,
+    },
+    updatedAt: canceledAt,
+  };
+
+  const event: SubscriptionDomainEvent = {
+    name: "subscription.canceled_now",
+    subscriptionId: next.id,
+    tenantId: next.tenantId,
+    occurredAt: canceledAt,
+    payload: {
+      previousStatus: current.status,
+      nextStatus: next.status,
+    },
+  };
+
+  return { next, event };
+}
+
+export function applyCancelAtPeriodEnd(
+  current: Subscription,
+  occurredAt: string,
+): { next: Subscription; event: SubscriptionDomainEvent } {
+  if (current.status === "canceled") {
+    throw new SubscriptionDomainError("Subscription is already canceled");
+  }
+
+  const next: Subscription = {
+    ...current,
+    cancelAtPeriodEnd: true,
+    updatedAt: occurredAt,
+  };
+
+  const event: SubscriptionDomainEvent = {
+    name: "subscription.cancel_at_period_end",
+    subscriptionId: next.id,
+    tenantId: next.tenantId,
+    occurredAt,
+    payload: {
+      currentPeriodEnd: current.currentPeriod.endsAt,
+    },
+  };
+
+  return { next, event };
+}


### PR DESCRIPTION
## Context
Implements GL-006 subscription lifecycle with an explicit state machine, idempotent commands, and auditable transitions.

## What was implemented
- Added subscription contracts for lifecycle commands and events
- Implemented domain state machine and transition invariants
- Added application use cases for:
  - create
  - upgrade
  - downgrade
  - cancel now
  - cancel at period end
- Added idempotency handling for mutation commands
- Added structured audit/event emission on critical transitions
- Added API adapter handlers mapped to domain/application behavior

## Key guarantees
- Invalid transitions fail with domain conflict
- Valid transitions persist state and period correctly
- Commands are idempotent by key
- Every critical transition is traceable (`actor`, `reason`, `traceId`)

## Validation
- npm run typecheck
- npm run build
- npm run lint

## Out of scope
- Invoice generation (GL-007)
- Full payment processing (GL-008)
- Entitlements engine (GL-009)

Closes #7
