### PR TITLE
docs(readme): refresh project positioning and engineering baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,174 +1,175 @@
 # GrantLedger Platform
 
-A production-oriented TypeScript monorepo for a multi-tenant grants, billing, and entitlements platform.
+API-first, multi-tenant SaaS billing and entitlements platform built as a production-oriented TypeScript monorepo.
 
-## Why this project exists
+> Status: Active development (foundation completed, billing core in progress)
 
-GrantLedger is built to solve a common real-world problem: evolving critical billing and access-control flows without creating long-term architectural debt.
+## Purpose
 
-The repository prioritizes:
+GrantLedger was created to solve a practical backend problem: evolving billing and access-control workflows without creating long-term architectural debt.
 
-- clean boundaries between domain logic and infrastructure
-- predictable delivery through issue-driven increments
-- strict typing and quality gates for safer refactoring
+The project emphasizes:
+
+- explicit domain boundaries
+- predictable issue-driven delivery
+- strict typing and shared contracts
 - low coupling to external providers
+- auditable technical decisions
 
-## Current scope
+## Current Scope (Feb 2026)
 
 Delivered milestones:
 
-- GL-001: Monorepo bootstrap and engineering baseline
-- GL-002: Authentication, memberships, and tenant request context
-- GL-003: Idempotency-key baseline for write operations
-- GL-004: Payment provider abstraction baseline
+- GL-001: monorepo bootstrap and engineering baseline
+- GL-002: authentication, memberships, and tenant request context
+- GL-003: idempotency baseline for write operations
+- GL-004: payment provider abstraction baseline
+- GL-005: versioned plan catalog with immutable published versions
+- GL-006: subscription state machine with idempotent commands
 
-## Architecture principles
+## Implemented Behavior Baselines
 
-- Domain-first: core business rules stay framework-agnostic
-- Ports/adapters: external integrations are injected behind interfaces
-- Explicit contracts: shared types are centralized and versioned in the monorepo
-- Incremental evolution: each issue adds capability without breaking previous boundaries
+### Auth and tenant context
+
+- missing authenticated user -> `401`
+- missing tenant header/context -> `400`
+- no active membership for tenant -> `403`
+- valid tenant membership -> `200`
+
+### Idempotent writes
+
+- missing idempotency key -> `400`
+- first write with new key -> `201`
+- same key + same payload -> `200` (replay)
+- same key + different payload -> `409`
+
+### Subscription lifecycle
+
+- explicit create/upgrade/downgrade/cancel commands
+- invalid transitions fail with domain conflict
+- command-level idempotency for mutation safety
+- structured audit/domain events for critical transitions
+
+## Architecture
+
+Core principles:
+
+- Domain-first: business rules remain framework-agnostic
+- Ports/adapters: integrations are injected behind interfaces
+- Explicit contracts: shared types are centralized in `packages/contracts`
+- Incremental evolution: each issue adds one coherent capability
 
 Dependency direction:
 
-- packages/domain -> no framework dependency
-- packages/application -> depends on packages/domain and packages/contracts
-- apps/* -> depend on packages/application and packages/contracts
+- `packages/domain` -> no framework dependency
+- `packages/application` -> depends on `packages/domain` and `packages/contracts`
+- `apps/*` -> consumes application use cases and contracts
 
-## Repository layout
+Repository layout:
 
-Project root:
+```txt
+apps/
+  api/
+  worker/
+  admin/
 
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform
+packages/
+  contracts/
+  domain/
+  application/
+  shared/
 
-Main folders:
+docs/
+  adr/
+```
 
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/apps/api
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/apps/worker
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/apps/admin
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/packages/contracts
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/packages/domain
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/packages/application
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/packages/shared
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/docs/adr
+## Engineering Maturity
 
-## Implemented behavior baselines
+Current baseline:
 
-Auth + tenant context (GL-002):
+- TypeScript strict mode with project references
+- ESLint configured for workspace-level quality
+- ADR-driven architecture decisions
+- issue-to-branch-to-PR workflow discipline
 
-- missing authenticated user -> 401
-- missing tenant context/header -> 400
-- no active membership for tenant -> 403
-- valid context -> 200
+Planned next maturity step:
 
-Idempotent writes (GL-003):
+- GL-012: formal quality gates with unit/integration/contract/E2E tests and CI/CD enforcement
 
-- missing idempotency key -> 400
-- first successful write -> 201
-- replay with same key and same payload -> 200
-- same key with different payload -> 409
-
-Payment abstraction (GL-004):
-
-- application layer depends on provider interface, not vendor SDK
-- fake provider validates flow and contract behavior
-- path prepared for real provider integration with minimal core impact
-
-## Tech stack
+## Tech Stack
 
 - Node.js 22.x
-- TypeScript with strict mode
-- exactOptionalPropertyTypes enabled
+- TypeScript (strict mode + exact optional property types)
 - npm workspaces
 - ESLint
-- project references (tsc -b)
+- project references (`tsc -b`)
 
-## Getting started
+## Getting Started
 
 Prerequisites:
 
-- Node.js >= 22
-- npm >= 10
+- Node.js `>=22 <23`
+- npm `>=10 <11`
 
 Install dependencies:
 
-- npm ci
+```bash
+npm ci
+```
 
 Run quality gates:
 
-- npm run typecheck
-- npm run build
-- npm run lint
+```bash
+npm run typecheck
+npm run build
+npm run lint
+```
 
-## Development workflow
+## Development Workflow
 
-Branching standard:
+Branch naming:
 
-- feat/`<issue>`-`<slug>`
-- fix/`<issue>`-`<slug>`
-- chore/`<issue>`-`<slug>`
+- `feat/<issue>-<slug>`
+- `fix/<issue>-<slug>`
+- `chore/<issue>-<slug>`
 
-Merge strategy:
-
-- Squash and Merge
-
-Operational rules:
+Delivery rules:
 
 - 1 issue = 1 branch = 1 PR
-- no direct commits to main
-- keep PR scope aligned to one issue
-- keep diffs focused and reviewable
-
-## Quality and review checklist
-
-Before opening or merging a PR:
-
-- typecheck passes
-- build passes
-- lint passes
-- architecture boundaries remain respected
-- risks and trade-offs are documented in PR description
+- no direct commits to `main`
+- keep PR scope aligned with one issue
+- use Squash and Merge
+- document risks and trade-offs in PR body
 
 ## ADRs (Architecture Decision Records)
 
-Location:
+Location: `docs/adr`
 
-- /Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/docs/adr
-
-ADRs are required when a decision has long-term architectural impact.
-
-## Project links
-
-- Repository: https://github.com/john-dalmolin/grantledger-platform
-- Board: https://github.com/users/john-dalmolin/projects/6
-
-## Important talking points
-
-This project demonstrates practical senior-level concerns:
-
-- clean architecture in a real monorepo
-- business-critical idempotency modeling
-- multi-tenant authorization context enforcement
-- integration-ready payment abstraction
-- disciplined issue-to-PR delivery process
+- `ADR-001-tenancy-model.md`
+- `ADR-002-entitlements-model.md`
+- `ADR-003-idempotency.md`
+- `ADR-004-payment-provider-abstraction.md`
 
 ## Roadmap
 
-- Integrate real payment provider adapter
-- Add webhook handling and reconciliation flows
-- Expand test coverage by layer (domain/application/adapters)
-- Strengthen observability and security controls
-- Document operational runbooks for incidents
+- GL-007: deterministic invoice engine
+- GL-008: Stripe adapter and payment processing flow
+- GL-009: entitlements engine (capabilities + limits)
+- GL-010: transactional outbox + retries + DLQ
+- GL-011: operational observability (logs, metrics, tracing, SLOs)
+- GL-012: quality and CI/CD gates (unit, integration, contract, E2E)
 
-## Contributing
+## Project Links
 
-Contributions should follow the issue-driven workflow and pass all quality gates before review.
+- Repository: [github.com/john-dalmolin/grantledger-platform](https://github.com/john-dalmolin/grantledger-platform)
+- Board: [github.com/users/john-dalmolin/projects/6](https://github.com/users/john-dalmolin/projects/6)
 
-## README structure references
+## Portfolio Highlights
 
-This README structure follows guidance from:
+This repository demonstrates practical senior backend concerns:
 
-- https://docs.github.com/en/enterprise-cloud@latest/repositories/creating-and-managing-repositories/best-practices-for-repositories
-- https://google.github.io/styleguide/docguide/READMEs.html
-- https://google.github.io/styleguide/docguide/style.html
-- https://www.makeareadme.com/
+- multi-tenant architecture with explicit boundaries
+- idempotency modeled as a first-class concern
+- auditable subscription workflows
+- provider-agnostic payment design
+- disciplined issue-to-PR delivery


### PR DESCRIPTION
## Summary
- rewrites README in English with a clearer senior-level narrative
- updates delivered scope (GL-001 to GL-006), architecture, and roadmap
- improves structure for technical review and portfolio presentation

## Validation
- documentation-only change
- no runtime behavior changes