### PR TITLE
feat(gl-008): add payment webhook abstraction with canonical events and dedup flow

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -306,3 +306,42 @@ export interface InvoiceAuditEvent {
   occurredAt: string;
   metadata: Record<string, string>;
 }
+
+// GL-008 - Canonical payments contracts
+
+// export type PaymentProviderName = "stripe";
+
+export type CanonicalPaymentEventType =
+  | "payment.succeeded"
+  | "payment.failed"
+  | "invoice.paid"
+  | "invoice.payment_failed"
+  | "subscription.updated"
+  | "subscription.canceled";
+
+export interface CanonicalPaymentEvent {
+  provider: PaymentProviderName;
+  eventId: string;
+  type: CanonicalPaymentEventType;
+  domainEventVersion: "v1";
+  occurredAt: string;
+  tenantId?: string;
+  subscriptionId?: string;
+  traceId: string;
+  payload: Record<string, string>;
+}
+
+export interface PaymentWebhookEnvelope {
+  provider: PaymentProviderName;
+  rawBody: string;
+  headers: Record<string, string | undefined>;
+  receivedAt: string;
+  traceId: string;
+}
+
+export interface PaymentWebhookProcessResult {
+  status: "processed" | "duplicate" | "rejected";
+  provider: PaymentProviderName;
+  eventId?: string;
+  reason?: string;
+}


### PR DESCRIPTION
## Context
Starts GL-008 with a safe incremental baseline for payment webhook processing, keeping billing core provider-agnostic.

## Scope of this PR (increment 1)
- Added canonical payment webhook contracts in `/Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/packages/contracts/src/index.ts`
- Added application-level webhook orchestration in `/Users/johndalmolin/Downloads/projetos/backend/nodejs/grantledger-platform/packages/application/src/index.ts`
- Introduced:
  - provider-agnostic webhook provider contract
  - dedup store contract (`provider + event_id`)
  - raw webhook audit store contract
  - canonical event publisher contract
  - `processProviderWebhook` use case with processed/duplicate/rejected flow

## Design decisions
- Domain/application remain decoupled from Stripe SDK.
- Canonical events are versioned via `domainEventVersion`.
- Raw payload persistence is part of the contract for future auditability.
- Deduplication is explicit and mandatory at use-case boundary.

## Validation
- npm run typecheck
- npm run build
- npm run lint

## Out of scope in this increment
- Stripe infrastructure adapter implementation
- signature verification wiring in API edge
- integration tests for webhook happy path/signature failure

These are planned for the next incremental PR(s) under GL-008.

Closes #9