### PR TITLE
chore(arch-003): adopt schema-first boundary validation with zod

### DIFF
--- a/apps/api/src/http/validation.ts
+++ b/apps/api/src/http/validation.ts
@@ -1,0 +1,31 @@
+import { BadRequestError } from "@grantledger/application";
+import { type ZodTypeAny } from "zod";
+
+function formatZodError(
+  issues: { path: PropertyKey[]; message: string }[],
+): string {
+  return issues
+    .map((issue) => {
+      const field =
+        issue.path.length > 0
+          ? issue.path.map((part) => String(part)).join(".")
+          : "payload";
+      return `${field}: ${issue.message}`;
+    })
+    .join("; ");
+}
+
+export function parseOrThrowBadRequest<TSchema extends ZodTypeAny>(
+  schema: TSchema,
+  input: unknown,
+  message = "Invalid request payload",
+): TSchema["_output"] {
+  const parsed = schema.safeParse(input);
+
+  if (!parsed.success) {
+    const details = formatZodError(parsed.error.issues);
+    throw new BadRequestError(`${message} - ${details}`);
+  }
+
+  return parsed.data;
+}

--- a/docs/adr/ADR-006-schema-first-validation-zod.md
+++ b/docs/adr/ADR-006-schema-first-validation-zod.md
@@ -1,0 +1,56 @@
+# ADR-006: Schema-First Boundary Validation with Zod
+
+- Status: Proposed
+- Date: 2026-02-19
+- Deciders: Platform Team
+
+## Context
+
+Boundary validation across API handlers and webhook ingestion is currently split between manual null checks and ad-hoc guards.
+
+This creates:
+
+- duplicated validation branches
+- weak runtime guarantees for external inputs
+- drift risk between runtime validation and TypeScript types
+
+## Decision
+
+Adopt **Zod** as runtime source of truth for boundary contracts and infer TypeScript types from schemas (`z.infer`) where applicable.
+
+Implementation defaults:
+
+- Canonical schemas live in `packages/contracts/src/schemas`.
+- API boundary handlers validate `payload`/`envelope` using shared schemas.
+- Validation failures map to `BadRequestError` (`HTTP 400`) at transport boundary.
+- Existing contracts remain backward-compatible during migration.
+
+## Consequences
+
+### Positive
+
+- Runtime validation and compile-time types stay aligned.
+- Less manual branching for required fields.
+- Better reuse of input contracts across adapters and handlers.
+
+### Trade-offs
+
+- New dependency (`zod`) in contracts package.
+- Initial migration effort to replace existing manual checks.
+- Need discipline for schema evolution/versioning.
+
+## Guardrails
+
+- Boundary schemas must be exported from contracts.
+- Handlers should avoid re-implementing field-required checks already covered by schemas.
+- Breaking schema changes require explicit compatibility note in PR.
+
+## Alternatives Considered
+
+- Keep manual guards + interfaces only: lower initial effort, higher long-term drift and inconsistency.
+- Validate only in API layer local schemas: faster start, but weak shared contract consistency.
+
+## Follow-up
+
+- Finalize status to `Accepted` once ARCH-003 is merged.
+- Reuse the same pattern in ARCH-004/005 as part of broader boundary standardization.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -6,8 +6,8 @@ Deliver structural improvements without blocking feature delivery.
 
 ## Canonical References
 
-- Guardrails: `ARCH-GUARDRAILS.md`
-- Roadmap: `IMPROVEMENT-ROADMAP.md`
+- Guardrails: `docs/architecture/ARCH-GUARDRAILS.md`
+- Roadmap: `docs/architecture/IMPROVEMENT-ROADMAP.md`
 - Boundary ADR: `docs/adr/ADR-005-domain-vs-application-boundary.md`
 
 ## Scope
@@ -59,9 +59,11 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `4cad15d`
   - Notes: Split monolithic indexes into context modules across domain/application/api.
 - [ ] ARCH-003 - Schema-first validation with Zod
-  - Status: TODO
+  - Status: IN_PROGRESS
+  - Issue: `#30`
+  - Branch: `chore/arch-003-schema-first-zod`
   - PR: _to be added_
-  - Notes: _to be added_
+  - Notes: Scope slice = API command inputs + checkout + webhook envelope validation with Zod, preserving backward-compatible contracts.
 - [ ] ARCH-004 - Timezone-safe date/time strategy (Luxon)
   - Status: TODO
   - PR: _to be added_
@@ -82,7 +84,7 @@ Deliver structural improvements without blocking feature delivery.
 ## ADR References
 
 - [x] ADR-005 - Domain vs Application boundary
-- [ ] ADR - Validation strategy (schema-first)
+- [x] ADR-006 - Validation strategy (schema-first, proposed)
 - [ ] ADR - Date/time and timezone policy
 - [ ] ADR - Error and response standardization
 - [ ] ADR - Idempotency strategy

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -6,15 +6,15 @@ This roadmap tracks architecture hardening as a continuous stream running in par
 
 Canonical references:
 
-- Tracker: `ARCH-TRACKER.md`
-- Guardrails: `ARCH-GUARDRAILS.md`
+- Tracker: `docs/architecture/ARCH-TRACKER.md`
+- Guardrails: `docs/architecture/ARCH-GUARDRAILS.md`
 - Boundary decision: `docs/adr/ADR-005-domain-vs-application-boundary.md`
 
 ## Progress Snapshot
 
 - ARCH-001 completed (`#31`)
 - ARCH-002 completed (`#32`)
-- Next target: ARCH-003 (schema-first validation with Zod)
+- ARCH-003 in progress (`#30`, branch `chore/arch-003-schema-first-zod`)
 
 ## Target Architecture Principles
 
@@ -26,11 +26,18 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-1. ARCH-003: Schema-first validation with Zod
+1. ARCH-003: Schema-first validation with Zod (in progress)
 2. ARCH-004: Time strategy with Luxon + UTC policy
 3. ARCH-005: Standardized exception model and API response mapper
 4. ARCH-006: Generic idempotency executor
 5. ARCH-007: i18n foundation (`en_US`)
+
+## Current Execution Focus (ARCH-003)
+
+- Introduce canonical Zod schemas in `packages/contracts/src/schemas`.
+- Infer API payload types using `z.infer`.
+- Validate boundary inputs in API handlers and webhook envelope.
+- Preserve existing behavior and response compatibility.
 
 ## Delivery Strategy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,6 +1777,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/application": {
       "name": "@grantledger/application",
       "version": "0.1.0",
@@ -1790,7 +1799,8 @@
       "name": "@grantledger/contracts",
       "version": "0.1.0",
       "dependencies": {
-        "@grantledger/shared": "0.1.0"
+        "@grantledger/shared": "0.1.0",
+        "zod": "^4.3.6"
       }
     },
     "packages/domain": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,6 +10,7 @@
     "test": "node -e \"console.log('No tests yet: @grantledger/contracts')\""
   },
   "dependencies": {
-    "@grantledger/shared": "0.1.0"
+    "@grantledger/shared": "0.1.0",
+    "zod": "^4.3.6"
   }
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -348,3 +348,5 @@ export interface PaymentWebhookProcessResult {
   eventId?: string;
   reason?: string;
 }
+
+export * from "./schemas/index.js";

--- a/packages/contracts/src/schemas/checkout-api.ts
+++ b/packages/contracts/src/schemas/checkout-api.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+import {
+  billingPeriodSchema,
+  nonEmptyStringSchema,
+} from "./common.js";
+
+export const startCheckoutPayloadSchema = z
+  .object({
+    planId: nonEmptyStringSchema,
+    billingPeriod: billingPeriodSchema,
+    successUrl: nonEmptyStringSchema.optional(),
+    cancelUrl: nonEmptyStringSchema.optional(),
+    externalReference: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type StartCheckoutPayload = z.infer<typeof startCheckoutPayloadSchema>;

--- a/packages/contracts/src/schemas/common.ts
+++ b/packages/contracts/src/schemas/common.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const nonEmptyStringSchema = z.string().trim().min(1);
+
+// We keep compatibility broad for now; timezone strictness will be hardened in ARCH-004.
+export const dateTimeStringSchema = nonEmptyStringSchema;
+
+export const billingPeriodSchema = z.enum(["monthly", "yearly"]);
+
+export const paymentProviderNameSchema = z.enum([
+  "fake",
+  "stripe",
+  "paypal",
+  "adyen",
+  "braintree",
+]);
+
+export const headersRecordSchema = z.record(z.string(), z.string().optional());

--- a/packages/contracts/src/schemas/index.ts
+++ b/packages/contracts/src/schemas/index.ts
@@ -1,0 +1,4 @@
+export * from "./common.js";
+export * from "./subscription-api.js";
+export * from "./checkout-api.js";
+export * from "./webhook.js";

--- a/packages/contracts/src/schemas/subscription-api.ts
+++ b/packages/contracts/src/schemas/subscription-api.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+
+import { dateTimeStringSchema, nonEmptyStringSchema } from "./common.js";
+
+export const createSubscriptionCommandPayloadSchema = z
+  .object({
+    subscriptionId: nonEmptyStringSchema,
+    tenantId: nonEmptyStringSchema,
+    customerId: nonEmptyStringSchema,
+    planId: nonEmptyStringSchema,
+    currentPeriodStart: dateTimeStringSchema,
+    currentPeriodEnd: dateTimeStringSchema,
+    trialEndsAt: dateTimeStringSchema.optional(),
+    reason: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type CreateSubscriptionCommandPayload = z.infer<
+  typeof createSubscriptionCommandPayloadSchema
+>;
+
+export const upgradeSubscriptionCommandPayloadSchema = z
+  .object({
+    subscriptionId: nonEmptyStringSchema,
+    nextPlanId: nonEmptyStringSchema,
+    effectiveAt: dateTimeStringSchema,
+    reason: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type UpgradeSubscriptionCommandPayload = z.infer<
+  typeof upgradeSubscriptionCommandPayloadSchema
+>;
+
+export const downgradeSubscriptionCommandPayloadSchema = z
+  .object({
+    subscriptionId: nonEmptyStringSchema,
+    nextPlanId: nonEmptyStringSchema,
+    effectiveAt: dateTimeStringSchema,
+    reason: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type DowngradeSubscriptionCommandPayload = z.infer<
+  typeof downgradeSubscriptionCommandPayloadSchema
+>;
+
+export const cancelSubscriptionNowCommandPayloadSchema = z
+  .object({
+    subscriptionId: nonEmptyStringSchema,
+    canceledAt: dateTimeStringSchema,
+    reason: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type CancelSubscriptionNowCommandPayload = z.infer<
+  typeof cancelSubscriptionNowCommandPayloadSchema
+>;
+
+export const cancelSubscriptionAtPeriodEndCommandPayloadSchema = z
+  .object({
+    subscriptionId: nonEmptyStringSchema,
+    reason: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type CancelSubscriptionAtPeriodEndCommandPayload = z.infer<
+  typeof cancelSubscriptionAtPeriodEndCommandPayloadSchema
+>;
+
+export const createSubscriptionPayloadSchema = z
+  .object({
+    planId: nonEmptyStringSchema,
+    externalReference: nonEmptyStringSchema.optional(),
+  })
+  .passthrough();
+
+export type CreateSubscriptionPayload = z.infer<
+  typeof createSubscriptionPayloadSchema
+>;

--- a/packages/contracts/src/schemas/webhook.ts
+++ b/packages/contracts/src/schemas/webhook.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import {
+  dateTimeStringSchema,
+  headersRecordSchema,
+  nonEmptyStringSchema,
+  paymentProviderNameSchema,
+} from "./common.js";
+
+export const paymentWebhookEnvelopeSchema = z
+  .object({
+    provider: paymentProviderNameSchema,
+    rawBody: nonEmptyStringSchema,
+    headers: headersRecordSchema,
+    receivedAt: dateTimeStringSchema,
+    traceId: nonEmptyStringSchema,
+  })
+  .passthrough();
+
+export type PaymentWebhookEnvelopeInput = z.infer<
+  typeof paymentWebhookEnvelopeSchema
+>;
+
+export const stripeProviderEventSchema = z
+  .object({
+    id: nonEmptyStringSchema,
+    type: nonEmptyStringSchema,
+    created: z.number().int(),
+    data: z
+      .object({
+        object: z.record(z.string(), z.unknown()).optional(),
+      })
+      .optional(),
+  })
+  .passthrough();
+
+export type StripeProviderEvent = z.infer<typeof stripeProviderEventSchema>;


### PR DESCRIPTION
## Summary
Implements ARCH-003 with a controlled schema-first slice across contracts and API boundaries, using Zod as runtime source of truth and inferred types for compile-time alignment.

## What changed
- Added canonical Zod schemas in `packages/contracts/src/schemas`:
- `packages/contracts/src/schemas/common.ts`
- `packages/contracts/src/schemas/subscription-api.ts`
- `packages/contracts/src/schemas/checkout-api.ts`
- `packages/contracts/src/schemas/webhook.ts`
- `packages/contracts/src/schemas/index.ts` (barrel)
- Added `zod` dependency to `@grantledger/contracts`.
- Re-exported schema modules from `packages/contracts/src/index.ts`.
- Added API validation helper:
- `apps/api/src/http/validation.ts` (`parseOrThrowBadRequest`)
- Migrated API boundary validation to schemas:
- `apps/api/src/handlers/auth.ts`
- `apps/api/src/handlers/checkout.ts`
- `apps/api/src/handlers/subscription.ts`
- Updated Stripe adapter parsing with schema-safe provider event validation:
- `apps/api/src/infrastructure/stripe/StripeWebhookProvider.ts`
- Added ADR for the architectural decision:
- `docs/adr/ADR-006-schema-first-validation-zod.md`
- Updated governance docs references/progress:
- `docs/architecture/ARCH-TRACKER.md`
- `docs/architecture/IMPROVEMENT-ROADMAP.md`

## Behavioral compatibility
- Keeps existing business behavior and response mapping intent.
- Reduces manual required-field branching at API boundaries.
- Validation failures are normalized via `BadRequestError` at transport boundary.

## Quality gates
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint`

## ARCH checklist
- [x] ARCH-TRACKER updated (current stage)
- [x] ADR created (`ADR-006`)
- [x] IMPROVEMENT-ROADMAP updated
- [x] Architectural scope reflected in PR
- [x] Next ARCH stage identified (ARCH-004)
