### PR TITLE
chore(arch-003): close governance after merge

### DIFF
--- a/docs/adr/ADR-006-schema-first-validation-zod.md
+++ b/docs/adr/ADR-006-schema-first-validation-zod.md
@@ -1,6 +1,6 @@
 # ADR-006: Schema-First Boundary Validation with Zod
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-02-19
 - Deciders: Platform Team
 
@@ -52,5 +52,4 @@ Implementation defaults:
 
 ## Follow-up
 
-- Finalize status to `Accepted` once ARCH-003 is merged.
 - Reuse the same pattern in ARCH-004/005 as part of broader boundary standardization.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -58,12 +58,13 @@ Deliver structural improvements without blocking feature delivery.
   - PR: `#32`
   - Merge SHA: `4cad15d`
   - Notes: Split monolithic indexes into context modules across domain/application/api.
-- [ ] ARCH-003 - Schema-first validation with Zod
-  - Status: IN_PROGRESS
+- [x] ARCH-003 - Schema-first validation with Zod
+  - Status: DONE
   - Issue: `#30`
   - Branch: `chore/arch-003-schema-first-zod`
-  - PR: _to be added_
-  - Notes: Scope slice = API command inputs + checkout + webhook envelope validation with Zod, preserving backward-compatible contracts.
+  - PR: `#34`
+  - Merge SHA: `dc7404d`
+  - Notes: Implemented schema-first boundary validation for subscription commands, checkout, and Stripe webhook parsing with canonical schemas in contracts.
 - [ ] ARCH-004 - Timezone-safe date/time strategy (Luxon)
   - Status: TODO
   - PR: _to be added_
@@ -84,7 +85,7 @@ Deliver structural improvements without blocking feature delivery.
 ## ADR References
 
 - [x] ADR-005 - Domain vs Application boundary
-- [x] ADR-006 - Validation strategy (schema-first, proposed)
+- [x] ADR-006 - Validation strategy (schema-first, accepted)
 - [ ] ADR - Date/time and timezone policy
 - [ ] ADR - Error and response standardization
 - [ ] ADR - Idempotency strategy

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -14,7 +14,7 @@ Canonical references:
 
 - ARCH-001 completed (`#31`)
 - ARCH-002 completed (`#32`)
-- ARCH-003 in progress (`#30`, branch `chore/arch-003-schema-first-zod`)
+- ARCH-003 completed (`#34`, merge `dc7404d`)
 
 ## Target Architecture Principles
 
@@ -26,18 +26,24 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-1. ARCH-003: Schema-first validation with Zod (in progress)
-2. ARCH-004: Time strategy with Luxon + UTC policy
+1. ARCH-003: Schema-first validation with Zod (completed)
+2. ARCH-004: Time strategy with Luxon + UTC policy (next)
 3. ARCH-005: Standardized exception model and API response mapper
 4. ARCH-006: Generic idempotency executor
 5. ARCH-007: i18n foundation (`en_US`)
 
-## Current Execution Focus (ARCH-003)
+## Completed Slice (ARCH-003)
 
 - Introduce canonical Zod schemas in `packages/contracts/src/schemas`.
 - Infer API payload types using `z.infer`.
 - Validate boundary inputs in API handlers and webhook envelope.
 - Preserve existing behavior and response compatibility.
+
+## Next Execution Focus (ARCH-004)
+
+- Define timezone-safe date/time policy.
+- Introduce Luxon-backed boundary/date parsing strategy.
+- Document UTC normalization and offset handling rules.
 
 ## Delivery Strategy
 


### PR DESCRIPTION
## Summary
Finalizes ARCH-003 governance artifacts after PR #34 merge.

## Changes
- Marked ARCH-003 as DONE in tracker with PR and merge SHA.
- Updated roadmap to reflect ARCH-003 completion and ARCH-004 as next focus.
- Set ADR-006 status to Accepted.

## Files
- docs/architecture/ARCH-TRACKER.md
- docs/architecture/IMPROVEMENT-ROADMAP.md
- docs/adr/ADR-006-schema-first-validation-zod.md

## Validation
- [x] npm run typecheck
- [x] npm run build
- [x] npm run lint
