### PR TITLE
chore(arch-004): close governance after merge

### DIFF
--- a/docs/adr/ADR-007-timezone-policy-luxon.md
+++ b/docs/adr/ADR-007-timezone-policy-luxon.md
@@ -48,5 +48,4 @@ Adopt Luxon-based datetime utilities as the canonical implementation for time pa
 
 ## Follow-up
 
-- Mark this ADR as `Accepted` when ARCH-004 is merged.
 - Reuse this policy in ARCH-005 for standardized error-to-response mapping.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -65,30 +65,35 @@ Deliver structural improvements without blocking feature delivery.
   - PR: `#34`
   - Merge SHA: `dc7404d`
   - Notes: Implemented schema-first boundary validation for subscription commands, checkout, and Stripe webhook parsing with canonical schemas in contracts.
-- [ ] ARCH-004 - Timezone-safe date/time strategy (Luxon)
-  - Status: IN_PROGRESS
+- [x] ARCH-004 - Timezone-safe date/time strategy (Luxon)
+  - Status: DONE
   - Issue: `#36`
   - Branch: `chore/arch-004-timezone-luxon-policy`
-  - PR: _to be added_
+  - PR: `#37`
+  - Merge SHA: `46e6804`
+  - Merge SHA: `46e6804`
   - Notes: Strict ISO-8601 datetime with explicit timezone offset, Luxon shared utilities, and critical Date migration.
 - [ ] ARCH-005 - Standard error model + API response mapping
   - Status: TODO
-  - PR: _to be added_
+  - PR: `#37`
+  - Merge SHA: `46e6804`
   - Notes: _to be added_
 - [ ] ARCH-006 - Generic idempotency executor
   - Status: TODO
-  - PR: _to be added_
+  - PR: `#37`
+  - Merge SHA: `46e6804`
   - Notes: _to be added_
 - [ ] ARCH-007 - i18n foundation (`en_US`)
   - Status: TODO
-  - PR: _to be added_
+  - PR: `#37`
+  - Merge SHA: `46e6804`
   - Notes: _to be added_
 
 ## ADR References
 
 - [x] ADR-005 - Domain vs Application boundary
 - [x] ADR-006 - Validation strategy (schema-first, accepted)
-- [ ] ADR-007 - Date/time and timezone policy (proposed)
+- [ ] ADR-007 - Date/time and timezone policy (accepted)
 - [ ] ADR - Error and response standardization
 - [ ] ADR - Idempotency strategy
 - [ ] ADR - i18n baseline approach

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -15,7 +15,7 @@ Canonical references:
 - ARCH-001 completed (`#31`)
 - ARCH-002 completed (`#32`)
 - ARCH-003 completed (`#34`, merge `dc7404d`)
-- ARCH-004 in progress (`#36`, branch `chore/arch-004-timezone-luxon-policy`)
+- ARCH-004 completed (`#37`, merge `46e6804`)
 
 ## Target Architecture Principles
 
@@ -27,7 +27,7 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-1. ARCH-004: Time strategy with Luxon + UTC policy (in progress)
+1. ARCH-004: Time strategy with Luxon + UTC policy (completed)
 2. ARCH-005: Standardized exception model and API response mapper
 3. ARCH-006: Generic idempotency executor
 4. ARCH-007: i18n foundation (`en_US`)


### PR DESCRIPTION
## Summary
Closes ARCH-004 governance after merge of PR #37.

## Changes
- Marks ARCH-004 as DONE in tracker.
- Adds PR and merge SHA references for ARCH-004.
- Updates roadmap to reflect ARCH-004 completion.
- Marks ADR-007 as Accepted.

## Files
- docs/architecture/ARCH-TRACKER.md
- docs/architecture/IMPROVEMENT-ROADMAP.md
- docs/adr/ADR-007-timezone-policy-luxon.md

## Validation
- [x] npm run typecheck
- [x] npm run build
- [x] npm run lint
