### PR TITLE
refactor(arch-006): introduce generic idempotency executor across application flows

### DIFF
--- a/apps/api/src/handlers/checkout.integration.test.ts
+++ b/apps/api/src/handlers/checkout.integration.test.ts
@@ -30,18 +30,19 @@ describe("checkout handler integration", () => {
 
     expect(response.status).toBe(400);
   });
-});
-it("returns 201 when payload is valid for authorized membership", async () => {
-  const response = await handleStartCheckout(
-    asHeaders({
-      "x-user-id": "u_1",
-      "x-tenant-id": "t_1",
-    }),
-    {
-      planId: "plan_basic",
-      billingPeriod: "monthly",
-    } as Parameters<typeof handleStartCheckout>[1],
-  );
 
-  expect(response.status).toBe(201);
+  it("returns 201 when payload is valid for authorized membership", async () => {
+    const response = await handleStartCheckout(
+      asHeaders({
+        "x-user-id": "u_1",
+        "x-tenant-id": "t_1",
+      }),
+      {
+        planId: "plan_basic",
+        billingPeriod: "monthly",
+      } as Parameters<typeof handleStartCheckout>[1],
+    );
+
+    expect(response.status).toBe(201);
+  });
 });

--- a/docs/adr/ADR-009-generic-idempotency-executor.md
+++ b/docs/adr/ADR-009-generic-idempotency-executor.md
@@ -1,0 +1,57 @@
+# ADR-009: Generic Async Idempotency Executor
+
+- Status: Proposed
+- Date: 2026-02-21
+- Deciders: Platform Team
+
+## Context
+
+Idempotency handling is currently split across flows:
+- Generic helper for some API paths.
+- Custom local orchestration in subscription use cases.
+- Separate dedup logic in payment-webhook flow.
+
+This fragmentation increases maintenance cost and semantic drift risk.
+
+## Decision
+
+Adopt a generic async idempotency executor in `@grantledger/application` as the canonical foundation.
+
+- Introduce `executeIdempotent(...)` with:
+  - logical `scope`
+  - required idempotency `key`
+  - async `store` abstraction (`get/set`)
+  - async `execute`
+  - deterministic payload hash by default
+- Keep `processWithIdempotency(...)` for compatibility as a wrapper path.
+- Migrate subscription flow to the shared executor.
+- Adopt key-based dedup mode for webhook flow in this stage (no payload conflict hash for webhook yet).
+
+## Consequences
+
+### Positive
+
+- Unified semantics for replay/conflict across application flows.
+- Lower duplication and easier evolution.
+- Cleaner boundary for storage adapters (in-memory/db/redis).
+
+### Trade-offs
+
+- Migration effort in existing flows.
+- Transitional period where compatibility wrapper still coexists.
+
+## Guardrails
+
+- No business rule change; only orchestration refactor.
+- Missing key remains client error.
+- Key reuse with different payload remains conflict in hash-enforced mode.
+- Webhook in this phase uses key-based dedup only.
+
+## Alternatives Considered
+
+- Keep separate implementations per flow: faster now, higher long-term drift.
+- Full strict payload-hash enforcement for webhook now: stronger guarantees but higher rollout complexity.
+
+## Follow-up
+
+- Mark this ADR as `Accepted` when ARCH-006 is merged.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -53,11 +53,13 @@ Deliver structural improvements without blocking feature delivery.
   - PR: `#31`
   - Merge SHA: `88787d7`
   - Notes: Added ADR-005 and baseline architecture guardrails/tracker.
+
 - [x] ARCH-002 - Modularize monolithic `index.ts`
   - Status: DONE
   - PR: `#32`
   - Merge SHA: `4cad15d`
   - Notes: Split monolithic indexes into context modules across domain/application/api.
+
 - [x] ARCH-003 - Schema-first validation with Zod
   - Status: DONE
   - Issue: `#30`
@@ -65,6 +67,7 @@ Deliver structural improvements without blocking feature delivery.
   - PR: `#34`
   - Merge SHA: `dc7404d`
   - Notes: Implemented schema-first boundary validation for subscription commands, checkout, and Stripe webhook parsing with canonical schemas in contracts.
+
 - [x] ARCH-004 - Timezone-safe date/time strategy (Luxon)
   - Status: DONE
   - Issue: `#36`
@@ -72,18 +75,23 @@ Deliver structural improvements without blocking feature delivery.
   - PR: `#37`
   - Merge SHA: `46e6804`
   - Notes: Strict ISO-8601 datetime with explicit timezone offset, Luxon shared utilities, and critical Date migration.
+
 - [x] ARCH-005 - Standard error model + centralized API mapping
-- Status: DONE
-- Issue: #39
-- Branch: chore/arch-005-error-model-api-mapper
-- PR: #40
-- Merge SHA: <b72ef69>
-- Notes: AppError base + centralized mapper + auth/checkout/subscription adoption + Vitest coverage delivered.
-- Residual risks: Remaining modules outside safe slice still use legacy/local mapping and should migrate in ARCH-006.
+  - Status: DONE
+  - Issue: `#39`
+  - Branch: `chore/arch-005-error-model-api-mapper`
+  - PR: `#40`
+  - Merge SHA: `b72ef69484dc898cc90d3feef4411b9e8e1914d6`
+  - Notes: AppError base + centralized mapper + auth/checkout/subscription adoption + Vitest coverage delivered.
+  - Residual risks: Remaining modules outside safe slice still use legacy/local mapping and should migrate in ARCH-006.
+
 - [ ] ARCH-006 - Generic idempotency executor
-  - Status: TODO
+  - Status: IN_PROGRESS
+  - Issue: `#42`
+  - Branch: `chore/arch-006-generic-idempotency-executor`
   - PR: _to be added_
-  - Notes: _to be added_
+  - Notes: Introduce generic async idempotency executor across auth/subscription/payment-webhook flows.
+
 - [ ] ARCH-007 - i18n foundation (`en_US`)
   - Status: TODO
   - PR: _to be added_
@@ -94,8 +102,8 @@ Deliver structural improvements without blocking feature delivery.
 - [x] ADR-005 - Domain vs Application boundary
 - [x] ADR-006 - Validation strategy (schema-first, accepted)
 - [x] ADR-007 - Date/time and timezone policy (accepted)
-- [ ] ADR-008 - Error and response standardization (proposed)
-- [ ] ADR - Idempotency strategy
+- [x] ADR-008 - Error and response standardization (accepted)
+- [ ] ADR-009 - Generic idempotency strategy (proposed)
 - [ ] ADR - i18n baseline approach
 
 ## Quality Gates (mandatory per PR)
@@ -103,7 +111,7 @@ Deliver structural improvements without blocking feature delivery.
 - [ ] `npm run typecheck`
 - [ ] `npm run build`
 - [ ] `npm run lint`
-- [ ] Architectural scope respected (no mixed feature work)
+- [ ] `Architectural scope respected (no mixed feature work)`
 
 ## Done Criteria for ARCH-000
 

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -17,6 +17,7 @@ Canonical references:
 - ARCH-003 completed (`#34`, merge `dc7404d`)
 - ARCH-004 completed (`#37`, merge `46e6804`)
 - ARCH-005 completed (`#40`, merge `b72ef69`)
+- ARCH-006 in progress (`#42`, branch `chore/arch-006-generic-idempotency-executor`)
 
 ## Target Architecture Principles
 
@@ -28,29 +29,15 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-2. ARCH-006: Generic idempotency executor (in progress)
-3. ARCH-007: i18n foundation (`en_US`)
-
-## Completed Slices
-
-### ARCH-003
-
-- Introduced canonical Zod schemas in `packages/contracts/src/schemas`.
-- Inferred API payload types using `z.infer`.
-- Validated boundary inputs in API handlers and webhook envelope.
-
-### ARCH-004
-
-- Defined timezone-safe datetime policy with Luxon.
-- Enforced explicit timezone offset at boundaries.
-- Standardized UTC timestamp generation utilities.
+1. ARCH-006: Generic idempotency executor (in progress)
+2. ARCH-007: i18n foundation (`en_US`)
 
 ## Next execution focus: ARCH-006
 
-- API error payload standardized with message + code + optional details/traceId.
-- Backward compatibility preserved via message field.
-- Central mapping reduces duplicated handler logic and inconsistency risk.
-- Remaining migration for modules outside safe slice is deferred to ARCH-006.
+- Introduce generic async idempotency executor in application layer.
+- Migrate subscription custom idempotency flow to shared foundation.
+- Align auth flow with shared executor.
+- Adopt key-based dedup orchestration in payment webhook flow.
 
 ## Delivery Strategy
 
@@ -62,27 +49,3 @@ Canonical references:
   - `npm run build`
   - `npm run lint`
   - `npm run test`
-
-## Mandatory Governance Workflow (Always)
-
-### Start of issue
-
-- Mark issue as `IN_PROGRESS` in `ARCH-TRACKER.md`.
-- Register issue link, branch name, and planned scope.
-- Update roadmap focus/dependencies.
-- Create ADR draft when new architectural decision is needed.
-
-### End of issue (before merge)
-
-- Mark issue as `DONE` in `ARCH-TRACKER.md`.
-- Register PR link and merged SHA.
-- Update roadmap next step and residual risks.
-- Finalize ADR changes or explicitly register `No ADR change required`.
-
-## Success Criteria for ARCH Stream
-
-- No core business logic concentrated in monolithic modules.
-- Layer boundaries are clear and reviewable.
-- Validation, time policy, and error mapping are standardized.
-- Idempotency orchestration is generic and reusable.
-- Governance docs stay synchronized with code and PR lifecycle.

--- a/packages/application/src/idempotency.test.ts
+++ b/packages/application/src/idempotency.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { IdempotencyRecord } from "@grantledger/contracts";
+import {
+  executeIdempotent,
+  IdempotencyConflictError,
+  MissingIdempotencyKeyError,
+  type AsyncIdempotencyStore,
+} from "./idempotency.js";
+
+function createStore<T>(): AsyncIdempotencyStore<T> {
+  const map = new Map<string, IdempotencyRecord<T>>();
+
+  return {
+    async get(scope: string, key: string) {
+      return map.get(`${scope}:${key}`) ?? null;
+    },
+    async set(scope: string, key: string, record: IdempotencyRecord<T>) {
+      map.set(`${scope}:${key}`, record);
+    },
+  };
+}
+
+describe("executeIdempotent", () => {
+  it("throws when idempotency key is missing", async () => {
+    await expect(
+      executeIdempotent({
+        scope: "test",
+        key: null,
+        payload: { a: 1 },
+        store: createStore<{ ok: boolean }>(),
+        execute: async () => ({ ok: true }),
+      }),
+    ).rejects.toBeInstanceOf(MissingIdempotencyKeyError);
+  });
+
+  it("executes first time and replays second time", async () => {
+    const store = createStore<{ ok: boolean }>();
+
+    const first = await executeIdempotent({
+      scope: "test",
+      key: "k1",
+      payload: { a: 1 },
+      store,
+      execute: async () => ({ ok: true }),
+    });
+
+    const second = await executeIdempotent({
+      scope: "test",
+      key: "k1",
+      payload: { a: 1 },
+      store,
+      execute: async () => ({ ok: false }),
+    });
+
+    expect(first.replayed).toBe(false);
+    expect(second.replayed).toBe(true);
+    expect(second.response).toEqual({ ok: true });
+  });
+
+  it("throws conflict for same key and different payload", async () => {
+    const store = createStore<{ ok: boolean }>();
+
+    await executeIdempotent({
+      scope: "test",
+      key: "k1",
+      payload: { a: 1 },
+      store,
+      execute: async () => ({ ok: true }),
+    });
+
+    await expect(
+      executeIdempotent({
+        scope: "test",
+        key: "k1",
+        payload: { a: 2 },
+        store,
+        execute: async () => ({ ok: true }),
+      }),
+    ).rejects.toBeInstanceOf(IdempotencyConflictError);
+  });
+});

--- a/packages/application/src/payment-webhook.test.ts
+++ b/packages/application/src/payment-webhook.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CanonicalPaymentEvent,
+  PaymentProviderName,
+} from "@grantledger/contracts";
+import {
+  processProviderWebhook,
+  type CanonicalPaymentEventPublisher,
+  type PaymentWebhookProvider,
+  type WebhookAuditStore,
+  type WebhookDedupStore,
+} from "./payment-webhook.js";
+
+class StubProvider implements PaymentWebhookProvider {
+  readonly provider: PaymentProviderName = "stripe";
+
+  async verifyAndNormalizeWebhook(): Promise<CanonicalPaymentEvent> {
+    return {
+      provider: "stripe",
+      eventId: "evt_1",
+      type: "payment.succeeded",
+      domainEventVersion: "v1",
+      occurredAt: "2026-02-21T10:00:00Z",
+      traceId: "trace_1",
+      payload: {},
+    };
+  }
+}
+
+class InMemoryDedupStore implements WebhookDedupStore {
+  private readonly set = new Set<string>();
+
+  async has(provider: PaymentProviderName, eventId: string): Promise<boolean> {
+    return this.set.has(`${provider}:${eventId}`);
+  }
+
+  async markProcessed(provider: PaymentProviderName, eventId: string): Promise<void> {
+    this.set.add(`${provider}:${eventId}`);
+  }
+}
+
+class NoopAuditStore implements WebhookAuditStore {
+  async saveRaw(): Promise<void> {}
+}
+
+class InMemoryPublisher implements CanonicalPaymentEventPublisher {
+  public count = 0;
+  async publish(): Promise<void> {
+    this.count += 1;
+  }
+}
+
+describe("payment webhook idempotency", () => {
+  it("processes first and returns duplicate on replay", async () => {
+    const publisher = new InMemoryPublisher();
+
+    const deps = {
+      provider: new StubProvider(),
+      dedupStore: new InMemoryDedupStore(),
+      auditStore: new NoopAuditStore(),
+      eventPublisher: publisher,
+    };
+
+    const input = {
+      provider: "stripe" as const,
+      rawBody: "{}",
+      headers: {},
+      receivedAt: "2026-02-21T10:00:00Z",
+      traceId: "trace_1",
+    };
+
+    const first = await processProviderWebhook(deps, input);
+    const second = await processProviderWebhook(deps, input);
+
+    expect(first.status).toBe("processed");
+    expect(second.status).toBe("duplicate");
+    expect(publisher.count).toBe(1);
+  });
+});

--- a/packages/application/src/subscription.idempotency.test.ts
+++ b/packages/application/src/subscription.idempotency.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Subscription,
+  SubscriptionAuditEvent,
+  SubscriptionDomainEvent,
+} from "@grantledger/contracts";
+import {
+  createSubscription,
+  SubscriptionConflictError,
+  type SubscriptionAuditLogger,
+  type SubscriptionEventPublisher,
+  type SubscriptionIdempotencyStore,
+  type SubscriptionIdempotencyStoreRecord,
+  type SubscriptionRepository,
+  type SubscriptionUseCaseDeps,
+} from "./subscription.js";
+
+class InMemorySubscriptionRepository implements SubscriptionRepository {
+  private readonly store = new Map<string, Subscription>();
+
+  async findById(subscriptionId: string): Promise<Subscription | null> {
+    return this.store.get(subscriptionId) ?? null;
+  }
+
+  async create(subscription: Subscription): Promise<void> {
+    this.store.set(subscription.id, subscription);
+  }
+
+  async save(subscription: Subscription): Promise<void> {
+    this.store.set(subscription.id, subscription);
+  }
+}
+
+class InMemorySubscriptionIdempotencyStore implements SubscriptionIdempotencyStore {
+  private readonly store = new Map<string, SubscriptionIdempotencyStoreRecord>();
+
+  async get(
+    command: string,
+    idempotencyKey: string,
+  ): Promise<SubscriptionIdempotencyStoreRecord | null> {
+    return this.store.get(`${command}:${idempotencyKey}`) ?? null;
+  }
+
+  async set(
+    command: string,
+    idempotencyKey: string,
+    record: SubscriptionIdempotencyStoreRecord,
+  ): Promise<void> {
+    this.store.set(`${command}:${idempotencyKey}`, record);
+  }
+}
+
+class NoopEventPublisher implements SubscriptionEventPublisher {
+  async publish(_event: SubscriptionDomainEvent): Promise<void> {
+    void _event;
+  }
+}
+
+class NoopAuditLogger implements SubscriptionAuditLogger {
+  async log(_event: SubscriptionAuditEvent): Promise<void> {
+    void _event;
+  }
+}
+
+function makeDeps(): SubscriptionUseCaseDeps {
+  return {
+    repository: new InMemorySubscriptionRepository(),
+    idempotencyStore: new InMemorySubscriptionIdempotencyStore(),
+    eventPublisher: new NoopEventPublisher(),
+    auditLogger: new NoopAuditLogger(),
+  };
+}
+
+describe("subscription idempotency", () => {
+  it("replays create with same key and same payload", async () => {
+    const deps = makeDeps();
+
+    const input = {
+      subscriptionId: "sub_1",
+      tenantId: "t_1",
+      customerId: "c_1",
+      planId: "plan_1",
+      currentPeriod: {
+        startsAt: "2026-02-21T10:00:00Z",
+        endsAt: "2026-03-21T10:00:00Z",
+      },
+      context: {
+        actor: { id: "u_1", type: "user" as const },
+        reason: "test",
+        traceId: "trace-1",
+        requestedAt: "2026-02-21T10:00:00Z",
+        idempotencyKey: "idem-1",
+      },
+    };
+
+    const first = await createSubscription(deps, input);
+    const second = await createSubscription(deps, input);
+
+    expect(first.id).toBe(second.id);
+  });
+
+  it("conflicts when same subscription already exists with different idempotency key", async () => {
+    const deps = makeDeps();
+
+    const base = {
+      subscriptionId: "sub_1",
+      tenantId: "t_1",
+      customerId: "c_1",
+      planId: "plan_1",
+      currentPeriod: {
+        startsAt: "2026-02-21T10:00:00Z",
+        endsAt: "2026-03-21T10:00:00Z",
+      },
+      context: {
+        actor: { id: "u_1", type: "user" as const },
+        reason: "test",
+        traceId: "trace-1",
+        requestedAt: "2026-02-21T10:00:00Z",
+        idempotencyKey: "idem-1",
+      },
+    };
+
+    await createSubscription(deps, base);
+
+    await expect(
+      createSubscription(deps, {
+        ...base,
+        context: { ...base.context, idempotencyKey: "idem-2" },
+      }),
+    ).rejects.toBeInstanceOf(SubscriptionConflictError);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: "node",
-    include: ["apps/api/src/**/*.test.ts"],
+    include: ["apps/api/src/**/*.test.ts", "packages/application/src/**/*.test.ts"],
     globals: false,
   },
 });


### PR DESCRIPTION
Implements ARCH-006 with broad scope: generic async idempotency foundation in application layer, migration of subscription idempotency to shared executor, adoption of key-based webhook dedup flow, auth alignment, and expanded API+application test coverage. Includes governance kickoff updates and ADR-009 (proposed).