### PR TITLE
chore(arch-006): close governance after merge

### DIFF
--- a/docs/adr/ADR-009-generic-idempotency-executor.md
+++ b/docs/adr/ADR-009-generic-idempotency-executor.md
@@ -1,17 +1,17 @@
 # ADR-009: Generic Async Idempotency Executor
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-02-21
 - Deciders: Platform Team
 
 ## Context
 
-Idempotency handling is currently split across flows:
+Idempotency handling was split across flows:
 - Generic helper for some API paths.
 - Custom local orchestration in subscription use cases.
 - Separate dedup logic in payment-webhook flow.
 
-This fragmentation increases maintenance cost and semantic drift risk.
+This fragmentation increased maintenance cost and semantic drift risk.
 
 ## Decision
 
@@ -39,6 +39,7 @@ Adopt a generic async idempotency executor in `@grantledger/application` as the 
 
 - Migration effort in existing flows.
 - Transitional period where compatibility wrapper still coexists.
+- Webhook path now favors deterministic key-based dedup over payload-hash conflict checks.
 
 ## Guardrails
 
@@ -51,7 +52,3 @@ Adopt a generic async idempotency executor in `@grantledger/application` as the 
 
 - Keep separate implementations per flow: faster now, higher long-term drift.
 - Full strict payload-hash enforcement for webhook now: stronger guarantees but higher rollout complexity.
-
-## Follow-up
-
-- Mark this ADR as `Accepted` when ARCH-006 is merged.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -85,12 +85,14 @@ Deliver structural improvements without blocking feature delivery.
   - Notes: AppError base + centralized mapper + auth/checkout/subscription adoption + Vitest coverage delivered.
   - Residual risks: Remaining modules outside safe slice still use legacy/local mapping and should migrate in ARCH-006.
 
-- [ ] ARCH-006 - Generic idempotency executor
-  - Status: IN_PROGRESS
+- [x] ARCH-006 - Generic idempotency executor
+  - Status: DONE
   - Issue: `#42`
   - Branch: `chore/arch-006-generic-idempotency-executor`
-  - PR: _to be added_
-  - Notes: Introduce generic async idempotency executor across auth/subscription/payment-webhook flows.
+  - PR: `#43`
+  - Merge SHA: `0706202f196d3c7969d39bc79e80a6e7d3cfe4aa`
+  - Notes: Implemented generic async idempotency executor, migrated subscription and auth flows, and adopted key-based webhook dedup through shared foundation.
+  - Residual risks: Payload-hash conflict detection for webhook flows remains intentionally out of scope in this stage.
 
 - [ ] ARCH-007 - i18n foundation (`en_US`)
   - Status: TODO
@@ -103,7 +105,7 @@ Deliver structural improvements without blocking feature delivery.
 - [x] ADR-006 - Validation strategy (schema-first, accepted)
 - [x] ADR-007 - Date/time and timezone policy (accepted)
 - [x] ADR-008 - Error and response standardization (accepted)
-- [ ] ADR-009 - Generic idempotency strategy (proposed)
+- [x] ADR-009 - Generic idempotency strategy (accepted)
 - [ ] ADR - i18n baseline approach
 
 ## Quality Gates (mandatory per PR)

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -17,7 +17,7 @@ Canonical references:
 - ARCH-003 completed (`#34`, merge `dc7404d`)
 - ARCH-004 completed (`#37`, merge `46e6804`)
 - ARCH-005 completed (`#40`, merge `b72ef69`)
-- ARCH-006 in progress (`#42`, branch `chore/arch-006-generic-idempotency-executor`)
+- ARCH-006 completed (`#43`, merge `0706202`)
 
 ## Target Architecture Principles
 
@@ -29,15 +29,13 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-1. ARCH-006: Generic idempotency executor (in progress)
-2. ARCH-007: i18n foundation (`en_US`)
+1. ARCH-007: i18n foundation (`en_US`)
 
-## Next execution focus: ARCH-006
+## Next execution focus: ARCH-007
 
-- Introduce generic async idempotency executor in application layer.
-- Migrate subscription custom idempotency flow to shared foundation.
-- Align auth flow with shared executor.
-- Adopt key-based dedup orchestration in payment webhook flow.
+- Build i18n baseline structure and message catalog strategy.
+- Keep runtime compatibility while introducing translation layer boundaries.
+- Reuse standardized error contract for localized message mapping in future steps.
 
 ## Delivery Strategy
 
@@ -49,3 +47,27 @@ Canonical references:
   - `npm run build`
   - `npm run lint`
   - `npm run test`
+
+## Mandatory Governance Workflow (Always)
+
+### Start of issue
+
+- Mark issue as `IN_PROGRESS` in `ARCH-TRACKER.md`.
+- Register issue link, branch name, and planned scope.
+- Update roadmap focus/dependencies.
+- Create ADR draft when new architectural decision is needed.
+
+### End of issue (before merge)
+
+- Mark issue as `DONE` in `ARCH-TRACKER.md`.
+- Register PR link and merged SHA.
+- Update roadmap next step and residual risks.
+- Finalize ADR changes or explicitly register `No ADR change required`.
+
+## Success Criteria for ARCH Stream
+
+- No core business logic concentrated in monolithic modules.
+- Layer boundaries are clear and reviewable.
+- Validation, time policy, and error mapping are standardized.
+- Idempotency orchestration is generic and reusable.
+- Governance docs stay synchronized with code and PR lifecycle.


### PR DESCRIPTION
Final governance closeout for ARCH-006 after PR #43 merge (SHA 0706202f196d3c7969d39bc79e80a6e7d3cfe4aa). Updates ARCH-TRACKER, IMPROVEMENT-ROADMAP and ADR-009 to final accepted state and sets next focus to ARCH-007.