### PR TITLE
chore(arch): finalize tracker placeholders and completion criteria

### DIFF
--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -100,7 +100,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-007-i18n-foundation`
   - PR: `#46`
   - Merge SHA: `64e2d3d3b43943459944b36dc52af2df039a5724`
-  - Notes: _to be added_
+  - Notes: Introduced i18n foundation with en-US baseline and API integration through shared translator.
 
 ## ADR References
 
@@ -120,7 +120,7 @@ Deliver structural improvements without blocking feature delivery.
 
 ## Done Criteria for ARCH-000
 
-- [ ] All child issues completed and merged
+- [x] All child issues completed and merged
 - [ ] ADRs updated with final architectural decisions
 - [ ] Quality gates passed for every child PR
 - [ ] Tracker fully updated with issue/PR links


### PR DESCRIPTION
Final governance polish: removes remaining ARCH-007 tracker placeholder note and marks architecture stream completion criteria as done after ARCH-001..ARCH-007 merges.