### PR TITLE
chore(arch-009): close governance after merge

### DIFF
--- a/docs/adr/ADR-013-async-idempotent-invoice-rollout.md
+++ b/docs/adr/ADR-013-async-idempotent-invoice-rollout.md
@@ -1,6 +1,6 @@
 # ADR-013: Async Idempotent Invoice Rollout
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-02-23
 - Deciders: Platform Team
 
@@ -42,4 +42,3 @@ Adopt an async invoice generation model with explicit job lifecycle and API idem
 ## Follow-up
 
 - ARCH-010 should harden infrastructure concerns (durable queue/store, retries/backoff, and operational observability).
-- Mark this ADR as `Accepted` when ARCH-009 is merged.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -112,12 +112,14 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `bef4fbc2eca25f136871109d09168293923f46ae`
   - Notes: Introduce stateful idempotency (`processing/completed/failed`), extract shared idempotency/error helpers, and formalize classes vs functions guideline.
 
-- [ ] ARCH-009 - Invoice idempotent use-case rollout (application + API + worker)
-  - Status: IN_PROGRESS
+- [x] ARCH-009 - Invoice idempotent use-case rollout (application + API + worker)
+  - Status: DONE
   - Issue: `#52`
   - Branch: `chore/arch-009-invoice-idempotent-rollout`
-  - PR: `_to be added_`
-  - Notes: Introduce async enqueue + worker processing for invoice generation with idempotency boundary on API (`Idempotency-Key`) and job status lifecycle.
+  - PR: `#53`
+  - Merge SHA: `591315941c9a0944cb353279ce651888462e2c6b`
+  - Notes: Delivered async invoice enqueue/status API, application idempotent enqueue/process/status use-cases, worker processing loop, and full coverage across application/API/worker.
+  - Residual risks: In-memory queue/idempotency storage is non-durable and must be replaced by persistent infrastructure in ARCH-010.
 
 ## ADR References
 
@@ -129,7 +131,7 @@ Deliver structural improvements without blocking feature delivery.
 - [x] ADR-010 - i18n foundation with `en_US` baseline (accepted)
 - [x] ADR-011 - Idempotency state machine and concurrency strategy (accepted)
 - [x] ADR-012 - Classes vs functions guideline (accepted)
-- [ ] ADR-013 - Async idempotent invoice rollout (proposed)
+- [x] ADR-013 - Async idempotent invoice rollout (accepted)
 
 ## Quality Gates (mandatory per PR)
 

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -20,7 +20,7 @@ Canonical references:
 - ARCH-006 completed (`#43`, merge `0706202`)
 - ARCH-007 completed (`#46`, merge `64e2d3d`)
 - ARCH-008 completed (`#49`, merge `bef4fbc`)
-- ARCH-009 in progress (`#52`, branch `chore/arch-009-invoice-idempotent-rollout`)
+- ARCH-009 completed (`#53`, merge `5913159`)
 
 ## Target Architecture Principles
 
@@ -32,16 +32,15 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-1. ARCH-009: invoice idempotent use-case rollout (application + API + worker) (in progress)
+1. ARCH-009: invoice idempotent use-case rollout (application + API + worker) (completed)
 2. ARCH-010: billing orchestration hardening follow-up (placeholder)
 
-## Next execution focus: ARCH-009
+## Next execution focus: ARCH-010
 
-- Reuse the stateful idempotency model (`processing/completed/failed`) in invoice async orchestration.
-- Introduce async invoice enqueue boundary with `Idempotency-Key` and `202 Accepted + jobId`.
-- Add worker-driven job lifecycle (`queued` -> `processing` -> `completed`/`failed`) and status endpoint.
-- Apply cycle-key + input-hash fingerprinting for invoice enqueue idempotency and deterministic replay.
-- Register ARCH-010 as the next placeholder stream after ARCH-009 closeout.
+- Replace in-memory invoice queue/idempotency stores with durable persistence.
+- Introduce retry/backoff and dead-letter handling for failed invoice jobs.
+- Add operational observability for queue latency, retry rate, and terminal failures.
+- Preserve API/application contracts delivered in ARCH-009 while evolving infrastructure.
 
 ## Delivery Strategy
 


### PR DESCRIPTION
Final governance closeout for ARCH-009 after PR #53 merge (SHA 591315941c9a0944cb353279ce651888462e2c6b). Updates tracker, roadmap, and ADR-013 to accepted/final state and sets next focus to ARCH-010.