### PR TITLE
chore(arch-012): close governance after merge

### DIFF
--- a/docs/adr/ADR-016-schema-first-time-policy-and-boundary-polish.md
+++ b/docs/adr/ADR-016-schema-first-time-policy-and-boundary-polish.md
@@ -1,6 +1,6 @@
 # ADR-016: Schema-First Contracts, Unified Time Policy, and Boundary Dedup Polish
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-02-24
 
 ## Context
@@ -50,4 +50,3 @@ Trade-offs:
 
 ## Follow-up
 
-- Mark this ADR as `Accepted` when ARCH-012 is merged.

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -138,11 +138,12 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `e58acbb87aba2eb334bf99d3f2d77d84c364434f`
   - Notes: Add operational observability, replay safeguards, and runbook-level guidance for async invoice flow without changing ARCH-009/010 API contracts.
 
-- [ ] ARCH-012 - Schema-first contracts, unified time policy, and boundary dedup polish
-  - Status: IN_PROGRESS
+- [x] ARCH-012 - Schema-first contracts, unified time policy, and boundary dedup polish
+  - Status: DONE
   - Issue: `#61`
   - Branch: `chore/arch-012-schema-time-boundaries`
-  - PR: `_to be added_`
+  - PR: `#65`
+  - Merge SHA: `ea6db9a73ac59e7fa2575808ae45d6f10c1701fb`
   - Notes: Enforce schema-first contracts (Zod as source of truth), unify Luxon datetime policy, and remove duplicated boundary orchestration while preserving API behavior.
 
 ## ADR References

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -23,7 +23,7 @@ Canonical references:
 - ARCH-009 completed (`#53`, merge `5913159`)
 - ARCH-010 completed (`#56`, merge `487c7bf`)
 - ARCH-011 completed (`#59`, merge `e58acbb`)
-- ARCH-012 in progress (`#61`, branch `chore/arch-012-schema-time-boundaries`)
+- ARCH-012 completed (`#65`, merge `ea6db9a`)
 
 ## Target Architecture Principles
 
@@ -75,7 +75,7 @@ Canonical references:
 - Idempotency orchestration is generic and reusable.
 - Governance docs stay synchronized with code and PR lifecycle.
 
-## Next execution focus: ARCH-012
+## Next execution focus: ARCH-013
 
 - Enforce schema-first contracts (Zod schemas as source of truth + inferred TypeScript types).
 - Unify datetime parsing/arithmetic through Luxon helpers in shared.


### PR DESCRIPTION
Final governance closeout for ARCH-012 after PR #65 merge (SHA ea6db9a73ac59e7fa2575808ae45d6f10c1701fb). Updates tracker, roadmap, and ADR-016 to accepted/final state and sets next focus to ARCH-013.

Closes #61