### PR TITLE
docs(readme): refresh architecture status through ARCH-012 and next focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It aims to give product and engineering teams confidence that billing behavior i
 - Schema-first invoice API contracts with Zod-inferred types to reduce contract drift.
 - Unified shared datetime policy (Luxon-based) across invoice orchestration paths.
 - Boundary-level payload normalization to reduce duplication and preserve API consistency.
+- Replay controls and observer-based operational hooks for async invoice lifecycle monitoring.
 - Async invoice generation flow across API + application + worker:
   - enqueue with `Idempotency-Key`
   - status polling by `jobId`


### PR DESCRIPTION
Final README senior polish after ARCH-012 completion.\n\nUpdates include:\n- ARCH-012 completion and ARCH-013 next focus at-a-glance\n- invoice async baseline naming aligned with ARCH-009/010/011/012\n- explicit current-state capabilities for schema-first contracts, Luxon policy, boundary dedup, and replay/observability\n- accepted ADR list updated through ADR-016\n- current trade-offs wording aligned with main branch reality