### PR TITLE
chore(arch-014): close governance after merge

### DIFF
--- a/docs/governance/closeouts/arch-014.md
+++ b/docs/governance/closeouts/arch-014.md
@@ -1,0 +1,15 @@
+# ARCH-014 Closeout
+
+## Delivery
+- PR principal: #80
+- Resultado: merged (squash) em `main`
+- Objetivo entregue: composition root + DI explícita na API (subscription handlers)
+
+## Governance
+- Issue #71: closed
+- Project V2 (PR #80): Status=Done, Priority=P2, Area=platform, Type=architecture, Wave=Wave 5, Risk=medium
+
+## Validation Evidence
+- npm run typecheck
+- npm run test
+- npm run quality:gate


### PR DESCRIPTION
## Summary
- closes governance cycle for ARCH-014 after merge of PR #80
- confirms project/issue metadata alignment in Wave 5
- records delivery evidence for tracking and auditability

## Why
- keep 1 ARCH = 1 delivery cycle fully closed
- ensure project board status and issue lifecycle stay consistent
- preserve professional governance baseline

## Scope
- governance closeout only (no runtime changes)

## Validation
- PR #80 merged successfully
- project metadata synced for PR/Issue
- issue closed with delivery reference

## Risks / Trade-offs
- no runtime risk (process-only change)

## Impact
- governance consistency improved
- delivery traceability finalized
