### PR TITLE
fix(api): restore checkout handler factory and shared runtime contracts

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./time.js";
+export * from "./runtime/index.js";
 export * from "./i18n/index.js";
 export * from "./errors/index.js";
 export * from "./idempotency/index.js";

--- a/packages/shared/src/runtime/clock.ts
+++ b/packages/shared/src/runtime/clock.ts
@@ -1,0 +1,16 @@
+import { utcNowIso } from "../time.js";
+
+export interface Clock {
+  now(): Date;
+  nowIso(): string;
+}
+
+export class SystemClock implements Clock {
+  now(): Date {
+    return new Date();
+  }
+
+  nowIso(): string {
+    return utcNowIso();
+  }
+}

--- a/packages/shared/src/runtime/id-generator.ts
+++ b/packages/shared/src/runtime/id-generator.ts
@@ -1,0 +1,11 @@
+import { randomUUID } from "node:crypto";
+
+export interface IdGenerator {
+  next(): string;
+}
+
+export class CryptoIdGenerator implements IdGenerator {
+  next(): string {
+    return randomUUID();
+  }
+}

--- a/packages/shared/src/runtime/index.ts
+++ b/packages/shared/src/runtime/index.ts
@@ -1,0 +1,2 @@
+export * from "./clock.js";
+export * from "./id-generator.js";


### PR DESCRIPTION
## Summary
- restores checkout handler factory export expected by composition root
- introduces shared runtime contracts (Clock, IdGenerator) and default implementations
- re-exports runtime module from @grantledger/shared

## Why
- main branch had API wiring drift after ARCH-014 merge
- this fix re-establishes compile/runtime consistency before ARCH-015

## Validation
- npm run typecheck
- npm run test
- npm run quality:gate

## Impact
- no API contract break
- low-risk baseline hardening