### PR TITLE
docs(arch-021): close out tracker and align CI check naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It aims to give product and engineering teams confidence that billing behavior i
 
 ## At a Glance
 
-> Current status on `main`: architecture hardening stream delivered through `ARCH-018`; active focus is `ARCH-021` (CI/CD quality + security gates).
+> Current status on `main`: architecture hardening stream delivered through `ARCH-021`; next planned focus is `ARCH-022` (performance, resilience, and readiness finalization).
 
 - domain rules stay pure and deterministic
 - use cases orchestrate idempotency, retries, and audit flow

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -154,11 +154,13 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `4c384d0`
   - Notes: Hardened schema-first request boundaries, added OpenAPI generation/validation scripts, and versioned OpenAPI artifact checks.
 
-- [ ] ARCH-021 - CI/CD quality and security gates
-  - Status: IN_PROGRESS
+- [x] ARCH-021 - CI/CD quality and security gates
+  - Status: DONE
   - Issue: `#78`
   - Branch: `chore/arch-021-ci-security-gates`
-  - Notes: Add GitHub Actions CI + security workflows, enforce OpenAPI drift checks, run Postgres integration in CI, and align branch protection.
+  - PR: `#90`
+  - Merge SHA: `b007968`
+  - Notes: Added CI quality/security workflows, enforced OpenAPI drift checks, enabled Postgres integration gates, and aligned main branch protection with required checks.
 
 ## ADR References
 
@@ -176,11 +178,8 @@ Deliver structural improvements without blocking feature delivery.
 
 ## Quality Gates (mandatory per PR)
 
-- [ ] `npm run typecheck`
-- [ ] `npm run build`
-- [ ] `npm run lint`
-- [ ] `npm run openapi:check`
-- [ ] `npm run test`
+- [ ] `npm run quality:gate`
+- [ ] `DATABASE_URL=postgresql://grantledger:grantledger@localhost:5432/grantledger RUN_PG_TESTS=1 npm run test:pg` (or CI evidence)
 - [ ] `Architectural scope respected (no mixed feature work)`
 
 ## Done Criteria for ARCH-000

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -25,7 +25,8 @@ Canonical references:
 - ARCH-011 completed (`#59`, merge `e58acbb`)
 - ARCH-012 completed (`#65`, merge `ea6db9a`)
 - ARCH-018 completed (`#89`, merge `4c384d0`)
-- ARCH-021 in progress (`#78`)
+- ARCH-021 completed (`#90`, merge `b007968`)
+- ARCH-022 planned (`#79`)
 
 ## Target Architecture Principles
 
@@ -38,9 +39,10 @@ Canonical references:
 ## Current Prioritized Sequence
 
 1. ARCH-018: schema-first boundaries and OpenAPI generation (completed)
-2. ARCH-021: CI/CD quality and security gates (in progress)
+2. ARCH-021: CI/CD quality and security gates (completed)
+3. ARCH-022: performance, resilience, and readiness finalization (planned)
 
-- Preserve API/application contracts delivered in ARCH-018 while introducing stricter delivery gates.
+- Preserve ARCH-018/ARCH-021 contract and delivery baselines while expanding operational readiness in ARCH-022.
 
 ## Delivery Strategy
 
@@ -76,9 +78,8 @@ Canonical references:
 - Idempotency orchestration is generic and reusable.
 - Governance docs stay synchronized with code and PR lifecycle.
 
-## Next execution focus: ARCH-021
+## Next execution focus: ARCH-022
 
-- Enforce lint/typecheck/build/OpenAPI/test gates in GitHub Actions.
-- Add Postgres-backed integration test execution in CI.
-- Add security scanning baseline (dependency audit + CodeQL).
-- Align branch protection policy with CI checks.
+- Finalize performance and resilience readiness checks on top of the new CI baseline.
+- Expand observability and operational readiness criteria for production confidence.
+- Keep CI/security gates stable while incrementally hardening runtime behavior.

--- a/docs/governance/delivery-standard.md
+++ b/docs/governance/delivery-standard.md
@@ -18,8 +18,8 @@
 
 ## Branch Protection Baseline
 - Protect `main` and require CI checks:
-- `CI / Quality Gate`
-- `CI / Postgres Integration`
+- `Quality Gate`
+- `Postgres Integration`
 - Keep security checks visible and actionable; move to blocking after baseline stabilization.
 
 ## PR Quality


### PR DESCRIPTION
## Summary
- close out ARCH-021 in tracker docs
- align CI check naming with enforced branch-protection contexts
- shift roadmap/readme focus to next architecture step

## Validation
- docs-only change
- no runtime behavior changes