### PR TITLE
docs(arch-018): record Redocly follow-up PRs in tracker and roadmap

### DIFF
--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -152,7 +152,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-018-schema-boundaries`
   - PR: `#89`
   - Merge SHA: `4c384d0`
-  - Notes: Hardened schema-first request boundaries, added OpenAPI generation/validation scripts, and versioned OpenAPI artifact checks.
+  - Notes: Hardened schema-first request boundaries, added OpenAPI generation/validation scripts, and versioned OpenAPI artifact checks. Follow-ups: `#92` migrated validation to Redocly and enriched generated OAS metadata; `#93` removed the legacy swagger-parser validator script.
 
 - [x] ARCH-021 - CI/CD quality and security gates
   - Status: DONE

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -24,7 +24,7 @@ Canonical references:
 - ARCH-010 completed (`#56`, merge `487c7bf`)
 - ARCH-011 completed (`#59`, merge `e58acbb`)
 - ARCH-012 completed (`#65`, merge `ea6db9a`)
-- ARCH-018 completed (`#89`, merge `4c384d0`)
+- ARCH-018 completed (`#89`, `#92`, `#93`; merges `4c384d0`, `3faf3f0`, `9da76c7`)
 - ARCH-021 completed (`#90`, merge `b007968`)
 - ARCH-022 planned (`#79`)
 


### PR DESCRIPTION
## Summary
- update ARCH-018 tracker notes with follow-up PRs #92 and #93
- update roadmap progress snapshot with merged SHAs

## Validation
- docs-only change