### PR TITLE
docs(governance): post-arch backlog refresh and monthly architecture health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It aims to give product and engineering teams confidence that billing behavior i
 
 ## At a Glance
 
-> Current status on `main`: architecture hardening stream is currently executing `ARCH-022` (performance, resilience, and readiness finalization).
+> Current status on `main`: architecture hardening baseline is completed through `ARCH-022`; next focus is backlog refresh based on concrete structural risks.
 
 - domain rules stay pure and deterministic
 - use cases orchestrate idempotency, retries, and audit flow
@@ -203,7 +203,7 @@ Architecture changes follow an issue-driven stream (`ARCH-*`) with mandatory doc
 - The repository still prioritizes deterministic in-memory adapters in key paths; a deeper durable production profile can continue in future streams.
 - Operational semantics (retry, backoff, dead-letter, replay controls, observer-safe notifications) are now modeled and documented across ARCH-010/011/012.
 - Contract drift risk was reduced by schema-first invoice boundaries, but broader schema-first consolidation can continue incrementally.
-- Next architecture step (`ARCH-022`) should finalize readiness targets while preserving public contracts and operational safeguards already stabilized.
+- Next architecture step should be opened as a new `ARCH-*` issue only when a concrete structural risk or bottleneck is identified.
 
 ## Project Links
 

--- a/docs/governance/architecture-health-check.md
+++ b/docs/governance/architecture-health-check.md
@@ -1,0 +1,19 @@
+# Architecture Health Check (Monthly)
+
+## Purpose
+Keep architecture baselines healthy after ARCH-022 without unnecessary process overhead.
+
+## Cadence
+- Monthly review (or after major incident)
+
+## Checklist
+1. CI/security/OpenAPI gates still green and enforced
+2. Error model and schema-first boundaries unchanged
+3. Runtime fail-fast guards still active
+4. Observability signals (latency/failure/queue depth) stable
+5. Decide: open new ARCH issue only if a concrete structural risk exists
+
+## Output
+- Short decision note in a GitHub issue:
+  - no action required, or
+  - create a new ARCH-* issue with scope and risk justification


### PR DESCRIPTION
## Summary
- update README status after ARCH-022 completion
- add monthly architecture health-check playbook

## Validation
- docs-only change