### PR TITLE
chore(ci): harden security workflow concurrency for pull requests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,8 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: security-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: security-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' }}
 
 jobs:
   dependency-audit:


### PR DESCRIPTION
## Summary
- scope security workflow concurrency by event and PR number/ref
- disable cancel-in-progress only for pull_request runs
- keep cancellation for push/schedule/workflow_dispatch to avoid runner waste

## Why
This reduces flaky cancellation noise (especially CodeQL) on active PRs while preserving efficient runner usage in non-PR events.