### PR TITLE
docs(arch): sync ARCH-023 completion into tracker and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It aims to give product and engineering teams confidence that billing behavior i
 
 ## At a Glance
 
-> Current status on `main`: architecture hardening baseline is completed through `ARCH-022`; next focus is backlog refresh based on concrete structural risks.
+> Current status on `main`: architecture hardening baseline is completed through `ARCH-023`; next focus is backlog refresh based on concrete structural risks.
 
 - domain rules stay pure and deterministic
 - use cases orchestrate idempotency, retries, and audit flow

--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -186,6 +186,14 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `fb43b20`
   - Notes: Finalized readiness baseline with SLI/SLO targets, alert/runbook guidance, and API startup fail-fast runtime validation.
 
+- [x] ARCH-023 - Postgres persistence regression coverage hardening
+  - Status: DONE
+  - Issue: `#114`
+  - Branch: `feat/arch-023-pg-persistence-regression-tests`
+  - PR: `#115`
+  - Merge SHA: `e7495526b79c558cead94e05d052c8fb694f79a6`
+  - Notes: Added Postgres integration regression coverage for idempotency begin/replay/conflict/restart flows, invoice job lease/retry/dead-letter guard behavior, and tenant-scoped persistence safety. No ADR change required.
+
 ## ADR References
 
 - [x] ADR-005 - Domain vs Application boundary

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -29,6 +29,7 @@ Canonical references:
 - ARCH-019 completed (`#95`, merge `e56fc1d`)
 - ARCH-020 completed (`#77`, branch `chore/arch-020-observability-baseline`)
 - ARCH-022 completed (`#99`, merge `fb43b20`)
+- ARCH-023 completed (`#115`, merge `e749552`)
 
 ## Target Architecture Principles
 
@@ -40,7 +41,7 @@ Canonical references:
 
 ## Current Prioritized Sequence
 
-- ARCH stream hardening baseline completed through ARCH-022.
+- ARCH stream hardening baseline completed through ARCH-023.
 - New architecture increments should open new ARCH issues from concrete risks.
 
 ## Delivery Strategy

--- a/docs/governance/architecture-health-check.md
+++ b/docs/governance/architecture-health-check.md
@@ -1,7 +1,7 @@
 # Architecture Health Check (Monthly)
 
 ## Purpose
-Keep architecture baselines healthy after ARCH-022 without unnecessary process overhead.
+Keep architecture baselines healthy after ARCH-023 without unnecessary process overhead.
 
 ## Cadence
 - Monthly review (or after major incident)


### PR DESCRIPTION
## Summary
- sync README, ARCH tracker, roadmap, and health-check docs with the completed ARCH-023 cycle
- register issue, branch, PR, and merge SHA references for the delivered postgres persistence regression coverage work
- keep architecture baseline status aligned with current `main`

## Validation
- documentation sync only; no product code changes

Closes #119
