### PR TITLE
feat(arch-024): durable webhook idempotency and audit persistence

### DIFF
--- a/apps/api/src/handlers/webhook.integration.test.ts
+++ b/apps/api/src/handlers/webhook.integration.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   InvalidWebhookSignatureError,
+  createInMemoryAsyncIdempotencyStore,
   type CanonicalPaymentEventPublisher,
   type PaymentWebhookProvider,
   type WebhookAuditStore,
-  type WebhookDedupStore,
 } from "@grantledger/application";
-import type { PaymentProviderName } from "@grantledger/contracts";
+import type { CanonicalPaymentEvent } from "@grantledger/contracts";
 import type { Headers } from "../http/types.js";
 import { handleProviderWebhook, type WebhookHandlerDeps } from "./webhook.js";
 
@@ -44,21 +44,6 @@ class SignatureFailureProvider implements PaymentWebhookProvider {
   }
 }
 
-class InMemoryDedupStore implements WebhookDedupStore {
-  private readonly keys = new Set<string>();
-
-  async has(provider: PaymentProviderName, eventId: string): Promise<boolean> {
-    return this.keys.has(`${provider}:${eventId}`);
-  }
-
-  async markProcessed(
-    provider: PaymentProviderName,
-    eventId: string,
-  ): Promise<void> {
-    this.keys.add(`${provider}:${eventId}`);
-  }
-}
-
 class NoopAuditStore implements WebhookAuditStore {
   async saveRaw(): Promise<void> { }
 }
@@ -87,7 +72,8 @@ function buildDeps(
   provider: PaymentWebhookProvider,
 ): WebhookHandlerDeps {
   return {
-    dedupStore: new InMemoryDedupStore(),
+    idempotencyStore:
+      createInMemoryAsyncIdempotencyStore<CanonicalPaymentEvent>(),
     auditStore: new NoopAuditStore(),
     eventPublisher: new NoopPublisher(),
     providerRegistry: {

--- a/apps/api/src/handlers/webhook.ts
+++ b/apps/api/src/handlers/webhook.ts
@@ -2,13 +2,20 @@ import {
   BadRequestError,
   InvalidWebhookSignatureError,
   processProviderWebhook,
+  createInMemoryAsyncIdempotencyStore,
+  type AsyncIdempotencyStore,
   type CanonicalPaymentEventPublisher,
   type PaymentWebhookProvider,
   type WebhookAuditStore,
-  type WebhookDedupStore,
 } from "@grantledger/application";
 import {
+  createPostgresPool,
+  createPostgresWebhookAuditStore,
+  createPostgresWebhookIdempotencyStore,
+} from "@grantledger/infra-postgres";
+import {
   paymentWebhookEnvelopeSchema,
+  type CanonicalPaymentEvent,
   type PaymentProviderName,
 } from "@grantledger/contracts";
 import { emitStructuredLog } from "@grantledger/shared";
@@ -18,21 +25,6 @@ import { toApiErrorResponse } from "../http/errors.js";
 import { getHeader } from "../http/headers.js";
 import type { ApiResponse, Headers } from "../http/types.js";
 import { parseOrThrowBadRequest } from "../http/validation.js";
-
-class InMemoryWebhookDedupStore implements WebhookDedupStore {
-  private readonly keys = new Set<string>();
-
-  async has(provider: PaymentProviderName, eventId: string): Promise<boolean> {
-    return this.keys.has(`${provider}:${eventId}`);
-  }
-
-  async markProcessed(
-    provider: PaymentProviderName,
-    eventId: string,
-  ): Promise<void> {
-    this.keys.add(`${provider}:${eventId}`);
-  }
-}
 
 class StructuredLogWebhookAuditStore implements WebhookAuditStore {
   async saveRaw(input: {
@@ -73,18 +65,31 @@ class StructuredLogCanonicalEventPublisher
 }
 
 export interface WebhookHandlerDeps {
-  dedupStore: WebhookDedupStore;
+  idempotencyStore: AsyncIdempotencyStore<CanonicalPaymentEvent>;
   auditStore: WebhookAuditStore;
   eventPublisher: CanonicalPaymentEventPublisher;
   providerRegistry?: Partial<Record<PaymentProviderName, PaymentWebhookProvider>>;
   stripeWebhookSecret?: string;
 }
 
-const defaultWebhookHandlerDeps: WebhookHandlerDeps = {
-  dedupStore: new InMemoryWebhookDedupStore(),
-  auditStore: new StructuredLogWebhookAuditStore(),
-  eventPublisher: new StructuredLogCanonicalEventPublisher(),
-};
+const defaultWebhookHandlerDeps: WebhookHandlerDeps = (() => {
+  if (process.env.PERSISTENCE_DRIVER === "postgres") {
+    const pool = createPostgresPool();
+
+    return {
+      idempotencyStore: createPostgresWebhookIdempotencyStore(pool),
+      auditStore: createPostgresWebhookAuditStore(pool),
+      eventPublisher: new StructuredLogCanonicalEventPublisher(),
+    };
+  }
+
+  return {
+    idempotencyStore:
+      createInMemoryAsyncIdempotencyStore<CanonicalPaymentEvent>(),
+    auditStore: new StructuredLogWebhookAuditStore(),
+    eventPublisher: new StructuredLogCanonicalEventPublisher(),
+  };
+})();
 
 function resolveProvider(
   providerName: PaymentProviderName,
@@ -96,7 +101,9 @@ function resolveProvider(
   }
 
   if (providerName === "stripe") {
-    const secret = (deps.stripeWebhookSecret ?? process.env.STRIPE_WEBHOOK_SECRET)?.trim();
+    const secret = (
+      deps.stripeWebhookSecret ?? process.env.STRIPE_WEBHOOK_SECRET
+    )?.trim();
     if (!secret) {
       throw new Error(
         "STRIPE_WEBHOOK_SECRET is required to process Stripe webhooks",
@@ -105,7 +112,7 @@ function resolveProvider(
     return new StripeWebhookProvider(secret);
   }
 
-  throw new BadRequestError(`Unsupported webhook provider: {providerName}`);
+  throw new BadRequestError(`Unsupported webhook provider: ${providerName}`);
 }
 
 function mapWebhookError(error: unknown): unknown {
@@ -136,7 +143,7 @@ export async function handleProviderWebhook(
     const result = await processProviderWebhook(
       {
         provider,
-        dedupStore: deps.dedupStore,
+        idempotencyStore: deps.idempotencyStore,
         auditStore: deps.auditStore,
         eventPublisher: deps.eventPublisher,
       },

--- a/db/migrations/0003_arch_024_webhook_persistence.sql
+++ b/db/migrations/0003_arch_024_webhook_persistence.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS payment_webhook_audits (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  provider TEXT NOT NULL,
+  trace_id TEXT NOT NULL,
+  raw_body TEXT NOT NULL,
+  headers JSONB NOT NULL,
+  received_at TIMESTAMPTZ NOT NULL,
+  event_id TEXT NULL,
+  status TEXT NOT NULL CHECK (status IN ('processed', 'duplicate', 'rejected')),
+  reason TEXT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS payment_webhook_audits_provider_event_idx
+  ON payment_webhook_audits (provider, event_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS payment_webhook_audits_status_created_idx
+  ON payment_webhook_audits (status, created_at DESC);

--- a/packages/application/src/payment-webhook.test.ts
+++ b/packages/application/src/payment-webhook.test.ts
@@ -11,8 +11,8 @@ import {
   type CanonicalPaymentEventPublisher,
   type PaymentWebhookProvider,
   type WebhookAuditStore,
-  type WebhookDedupStore,
 } from "./payment-webhook.js";
+import { createInMemoryAsyncIdempotencyStore } from "./idempotency.js";
 
 class StubProvider implements PaymentWebhookProvider {
   readonly provider: PaymentProviderName = "stripe";
@@ -47,18 +47,6 @@ class UnknownEventProvider implements PaymentWebhookProvider {
       eventId: "evt_unknown_1",
       providerEventType: "invoice.voided",
     });
-  }
-}
-
-class InMemoryDedupStore implements WebhookDedupStore {
-  private readonly set = new Set<string>();
-
-  async has(provider: PaymentProviderName, eventId: string): Promise<boolean> {
-    return this.set.has(`${provider}:${eventId}`);
-  }
-
-  async markProcessed(provider: PaymentProviderName, eventId: string): Promise<void> {
-    this.set.add(`${provider}:${eventId}`);
   }
 }
 
@@ -105,7 +93,8 @@ describe("payment webhook orchestration", () => {
 
     const deps = {
       provider: new StubProvider(),
-      dedupStore: new InMemoryDedupStore(),
+      idempotencyStore:
+        createInMemoryAsyncIdempotencyStore<CanonicalPaymentEvent>(),
       auditStore,
       eventPublisher: publisher,
     };
@@ -129,7 +118,8 @@ describe("payment webhook orchestration", () => {
 
     const deps = {
       provider: new InvalidSignatureProvider(),
-      dedupStore: new InMemoryDedupStore(),
+      idempotencyStore:
+        createInMemoryAsyncIdempotencyStore<CanonicalPaymentEvent>(),
       auditStore,
       eventPublisher: new InMemoryPublisher(),
     };
@@ -148,7 +138,8 @@ describe("payment webhook orchestration", () => {
 
     const deps = {
       provider: new UnknownEventProvider(),
-      dedupStore: new InMemoryDedupStore(),
+      idempotencyStore:
+        createInMemoryAsyncIdempotencyStore<CanonicalPaymentEvent>(),
       auditStore,
       eventPublisher: new InMemoryPublisher(),
     };

--- a/packages/application/src/payment-webhook.ts
+++ b/packages/application/src/payment-webhook.ts
@@ -3,7 +3,6 @@ import {
   CanonicalPaymentEvent,
   PaymentWebhookProcessResult,
   PaymentWebhookEnvelope,
-  IdempotencyRecord,
 } from "@grantledger/contracts";
 import {
   AsyncIdempotencyStore,
@@ -43,11 +42,6 @@ export interface PaymentWebhookProvider {
   }): Promise<CanonicalPaymentEvent>;
 }
 
-export interface WebhookDedupStore {
-  has(provider: PaymentProviderName, eventId: string): Promise<boolean>;
-  markProcessed(provider: PaymentProviderName, eventId: string): Promise<void>;
-}
-
 export interface WebhookAuditStore {
   saveRaw(input: {
     provider: PaymentProviderName;
@@ -67,37 +61,9 @@ export interface CanonicalPaymentEventPublisher {
 
 export interface PaymentWebhookDeps {
   provider: PaymentWebhookProvider;
-  dedupStore: WebhookDedupStore;
+  idempotencyStore: AsyncIdempotencyStore<CanonicalPaymentEvent>;
   auditStore: WebhookAuditStore;
   eventPublisher: CanonicalPaymentEventPublisher;
-}
-
-function toAsyncStore(
-  dedupStore: WebhookDedupStore,
-): AsyncIdempotencyStore<CanonicalPaymentEvent> {
-  return {
-    async get(
-      scope: string,
-      key: string,
-    ): Promise<IdempotencyRecord<CanonicalPaymentEvent> | null> {
-      const [provider] = scope.split(":") as [PaymentProviderName, string?];
-      const alreadyProcessed = await dedupStore.has(provider, key);
-      if (!alreadyProcessed) return null;
-
-      return {
-        key,
-        payloadHash: "null",
-        status: "completed",
-        response: {} as CanonicalPaymentEvent,
-        createdAt: "1970-01-01T00:00:00Z",
-        updatedAt: "1970-01-01T00:00:00Z",
-      };
-    },
-    async set(scope: string, key: string): Promise<void> {
-      const [provider] = scope.split(":") as [PaymentProviderName, string?];
-      await dedupStore.markProcessed(provider, key);
-    },
-  };
 }
 
 export async function processProviderWebhook(
@@ -117,7 +83,7 @@ export async function processProviderWebhook(
       scope,
       key: event.eventId,
       payload: null,
-      store: toAsyncStore(deps.dedupStore),
+      store: deps.idempotencyStore,
       execute: async () => {
         await deps.eventPublisher.publish(event);
         return event;

--- a/packages/infra-postgres/src/idempotency-store.integration.test.ts
+++ b/packages/infra-postgres/src/idempotency-store.integration.test.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { IdempotencyRecord } from "@grantledger/contracts";
 import type { Pool } from "pg";
 import { createPostgresAsyncIdempotencyStore, createPostgresPool } from "./index.js";
+import { applyPostgresTestMigrations } from "./test-migrations.js";
 
 const shouldRun =
   process.env.RUN_PG_TESTS === "1" && Boolean(process.env.DATABASE_URL);
@@ -23,24 +22,12 @@ function beginOrThrow<TResponse>(
   return store.begin;
 }
 
-async function applyMigrations(pool: Pool): Promise<void> {
-  const migrations = [
-    "db/migrations/0001_arch_015_core_tables.sql",
-    "db/migrations/0002_arch_016_worker_lease.sql",
-  ];
-
-  for (const migrationPath of migrations) {
-    const sql = readFileSync(resolve(process.cwd(), migrationPath), "utf8");
-    await pool.query(sql);
-  }
-}
-
 describePg("postgres idempotency store regression", () => {
   let pool: Pool;
 
   beforeAll(async () => {
     pool = createPostgresPool();
-    await applyMigrations(pool);
+    await applyPostgresTestMigrations(pool);
   });
 
   afterAll(async () => {

--- a/packages/infra-postgres/src/index.ts
+++ b/packages/infra-postgres/src/index.ts
@@ -4,4 +4,5 @@ export * from "./idempotency-store.js";
 export * from "./subscription-repository.js";
 export * from "./invoice-repository.js";
 export * from "./invoice-job-store.js";
+export * from "./webhook-stores.js";
 export * from "./use-case-deps.js";

--- a/packages/infra-postgres/src/invoice-job-store.integration.test.ts
+++ b/packages/infra-postgres/src/invoice-job-store.integration.test.ts
@@ -1,6 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   InvoiceJobLeaseError,
@@ -12,22 +10,11 @@ import {
   createPostgresInvoiceJobStore,
   createPostgresPool,
 } from "./index.js";
+import { applyPostgresTestMigrations } from "./test-migrations.js";
 
 const shouldRun =
   process.env.RUN_PG_TESTS === "1" && Boolean(process.env.DATABASE_URL);
 const describePg = shouldRun ? describe : describe.skip;
-
-async function applyMigrations(pool: Pool): Promise<void> {
-  const migrations = [
-    "db/migrations/0001_arch_015_core_tables.sql",
-    "db/migrations/0002_arch_016_worker_lease.sql",
-  ];
-
-  for (const migrationPath of migrations) {
-    const sql = readFileSync(resolve(process.cwd(), migrationPath), "utf8");
-    await pool.query(sql);
-  }
-}
 
 function buildInput(tenantId: string): GenerateInvoiceForCycleInput {
   return {
@@ -70,7 +57,7 @@ describePg("postgres invoice job store regression", () => {
 
   beforeAll(async () => {
     pool = createPostgresPool();
-    await applyMigrations(pool);
+    await applyPostgresTestMigrations(pool);
   });
 
   afterAll(async () => {

--- a/packages/infra-postgres/src/tenant-isolation.integration.test.ts
+++ b/packages/infra-postgres/src/tenant-isolation.integration.test.ts
@@ -1,6 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import type { IdempotencyRecord, Subscription } from "@grantledger/contracts";
 import type { Pool } from "pg";
@@ -9,6 +7,7 @@ import {
   createPostgresPool,
   createPostgresSubscriptionRepository,
 } from "./index.js";
+import { applyPostgresTestMigrations } from "./test-migrations.js";
 
 const shouldRun =
   process.env.RUN_PG_TESTS === "1" && Boolean(process.env.DATABASE_URL);
@@ -19,11 +18,7 @@ describePg("postgres tenant isolation", () => {
 
   beforeAll(async () => {
     pool = createPostgresPool();
-    const migrationSql = readFileSync(
-      resolve(process.cwd(), "db/migrations/0001_arch_015_core_tables.sql"),
-      "utf8",
-    );
-    await pool.query(migrationSql);
+    await applyPostgresTestMigrations(pool);
   });
 
   afterAll(async () => {

--- a/packages/infra-postgres/src/test-migrations.ts
+++ b/packages/infra-postgres/src/test-migrations.ts
@@ -1,0 +1,55 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Pool } from "pg";
+
+export async function applyPostgresTestMigrations(pool: Pool): Promise<void> {
+  const migrationsDir = resolve(process.cwd(), "db/migrations");
+  const migrationFiles = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+
+  const client = await pool.connect();
+
+  try {
+    // Prevent concurrent test suites from racing on DDL against the same DB.
+    await client.query("SELECT pg_advisory_lock($1)", [24_000_001]);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version TEXT PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `);
+
+    const appliedResult = await client.query<{ version: string }>(
+      "SELECT version FROM schema_migrations",
+    );
+    const appliedVersions = new Set(appliedResult.rows.map((row) => row.version));
+
+    for (const migrationFile of migrationFiles) {
+      if (appliedVersions.has(migrationFile)) {
+        continue;
+      }
+
+      const sql = readFileSync(resolve(migrationsDir, migrationFile), "utf8");
+
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
+        await client.query(
+          "INSERT INTO schema_migrations(version, applied_at) VALUES ($1, now())",
+          [migrationFile],
+        );
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      }
+    }
+  } finally {
+    try {
+      await client.query("SELECT pg_advisory_unlock($1)", [24_000_001]);
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/packages/infra-postgres/src/webhook-stores.integration.test.ts
+++ b/packages/infra-postgres/src/webhook-stores.integration.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  InvalidWebhookSignatureError,
+  processProviderWebhook,
+  type CanonicalPaymentEventPublisher,
+  type PaymentWebhookProvider,
+} from "@grantledger/application";
+import type {
+  CanonicalPaymentEvent,
+  PaymentWebhookEnvelope,
+  PaymentProviderName,
+} from "@grantledger/contracts";
+import type { Pool } from "pg";
+import {
+  createPostgresPool,
+  createPostgresWebhookAuditStore,
+  createPostgresWebhookIdempotencyStore,
+} from "./index.js";
+import { applyPostgresTestMigrations } from "./test-migrations.js";
+
+const shouldRun =
+  process.env.RUN_PG_TESTS === "1" && Boolean(process.env.DATABASE_URL);
+const describePg = shouldRun ? describe : describe.skip;
+
+type AuditRow = {
+  provider: PaymentProviderName;
+  event_id: string | null;
+  status: "processed" | "duplicate" | "rejected";
+  reason: string | null;
+  trace_id: string;
+};
+
+class FakeProvider implements PaymentWebhookProvider {
+  readonly provider = "stripe" as const;
+
+  constructor(private readonly eventId: string) {}
+
+  async verifyAndNormalizeWebhook(input: {
+    rawBody: string;
+    headers: Record<string, string | undefined>;
+    traceId: string;
+  }): Promise<CanonicalPaymentEvent> {
+    void input.rawBody;
+    void input.headers;
+
+    return {
+      provider: this.provider,
+      eventId: this.eventId,
+      type: "payment.succeeded",
+      domainEventVersion: "v1",
+      occurredAt: "2026-03-06T00:00:00Z",
+      traceId: input.traceId,
+      payload: { source: "pg-regression" },
+    };
+  }
+}
+
+class InvalidSignatureProvider implements PaymentWebhookProvider {
+  readonly provider = "stripe" as const;
+
+  async verifyAndNormalizeWebhook(): Promise<CanonicalPaymentEvent> {
+    throw new InvalidWebhookSignatureError("Invalid Stripe webhook signature");
+  }
+}
+
+class RecordingPublisher implements CanonicalPaymentEventPublisher {
+  public published: CanonicalPaymentEvent[] = [];
+
+  async publish(event: CanonicalPaymentEvent): Promise<void> {
+    this.published.push(event);
+  }
+}
+
+function buildInput(traceId: string): PaymentWebhookEnvelope {
+  return {
+    provider: "stripe",
+    rawBody: '{"id":"evt"}',
+    headers: {
+      "stripe-signature": "sig",
+    },
+    receivedAt: "2026-03-06T00:00:00Z",
+    traceId,
+  };
+}
+
+describePg("postgres webhook persistence regression", () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = createPostgresPool();
+    await applyPostgresTestMigrations(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("persists duplicate protection across new store instances", async () => {
+    const traceId = `trace_webhook_${randomUUID()}`;
+    const eventId = `evt_${randomUUID()}`;
+    const publisher = new RecordingPublisher();
+
+    const first = await processProviderWebhook(
+      {
+        provider: new FakeProvider(eventId),
+        idempotencyStore: createPostgresWebhookIdempotencyStore(pool),
+        auditStore: createPostgresWebhookAuditStore(pool),
+        eventPublisher: publisher,
+      },
+      buildInput(traceId),
+    );
+
+    const second = await processProviderWebhook(
+      {
+        provider: new FakeProvider(eventId),
+        idempotencyStore: createPostgresWebhookIdempotencyStore(pool),
+        auditStore: createPostgresWebhookAuditStore(pool),
+        eventPublisher: publisher,
+      },
+      buildInput(traceId),
+    );
+
+    expect(first).toMatchObject({
+      status: "processed",
+      provider: "stripe",
+      eventId,
+    });
+    expect(second).toMatchObject({
+      status: "duplicate",
+      provider: "stripe",
+      eventId,
+    });
+    expect(publisher.published).toHaveLength(1);
+
+    const auditResult = await pool.query<AuditRow>(
+      `SELECT provider, event_id, status, reason, trace_id
+         FROM payment_webhook_audits
+        WHERE trace_id = $1
+        ORDER BY id`,
+      [traceId],
+    );
+
+    expect(auditResult.rows).toHaveLength(2);
+    expect(auditResult.rows[0]).toMatchObject({
+      provider: "stripe",
+      event_id: eventId,
+      status: "processed",
+    });
+    expect(auditResult.rows[1]).toMatchObject({
+      provider: "stripe",
+      event_id: eventId,
+      status: "duplicate",
+      reason: "Duplicate webhook event",
+    });
+  });
+
+  it("persists rejected webhook audit rows", async () => {
+    const traceId = `trace_webhook_${randomUUID()}`;
+
+    await expect(
+      processProviderWebhook(
+        {
+          provider: new InvalidSignatureProvider(),
+          idempotencyStore: createPostgresWebhookIdempotencyStore(pool),
+          auditStore: createPostgresWebhookAuditStore(pool),
+          eventPublisher: new RecordingPublisher(),
+        },
+        buildInput(traceId),
+      ),
+    ).rejects.toBeInstanceOf(InvalidWebhookSignatureError);
+
+    const auditResult = await pool.query<AuditRow>(
+      `SELECT provider, event_id, status, reason, trace_id
+         FROM payment_webhook_audits
+        WHERE trace_id = $1
+        ORDER BY id DESC
+        LIMIT 1`,
+      [traceId],
+    );
+
+    expect(auditResult.rows).toHaveLength(1);
+    expect(auditResult.rows[0]).toMatchObject({
+      provider: "stripe",
+      event_id: null,
+      status: "rejected",
+      trace_id: traceId,
+    });
+    expect(auditResult.rows[0]?.reason).toContain(
+      "Invalid Stripe webhook signature",
+    );
+  });
+});

--- a/packages/infra-postgres/src/webhook-stores.ts
+++ b/packages/infra-postgres/src/webhook-stores.ts
@@ -1,0 +1,41 @@
+import type {
+  AsyncIdempotencyStore,
+  WebhookAuditStore,
+} from "@grantledger/application";
+import type { CanonicalPaymentEvent } from "@grantledger/contracts";
+import type { Pool } from "pg";
+import { createPostgresAsyncIdempotencyStore } from "./idempotency-store.js";
+
+const WEBHOOK_SYSTEM_TENANT_ID = "__webhook__";
+
+export function createPostgresWebhookIdempotencyStore(
+  pool: Pool,
+): AsyncIdempotencyStore<CanonicalPaymentEvent> {
+  return createPostgresAsyncIdempotencyStore<CanonicalPaymentEvent>(
+    pool,
+    WEBHOOK_SYSTEM_TENANT_ID,
+  );
+}
+
+export function createPostgresWebhookAuditStore(pool: Pool): WebhookAuditStore {
+  return {
+    async saveRaw(input): Promise<void> {
+      await pool.query(
+        `INSERT INTO payment_webhook_audits
+          (provider, trace_id, raw_body, headers, received_at, event_id, status, reason)
+         VALUES
+          ($1, $2, $3, $4::jsonb, $5::timestamptz, $6, $7, $8)`,
+        [
+          input.provider,
+          input.traceId,
+          input.rawBody,
+          JSON.stringify(input.headers),
+          input.receivedAt,
+          input.eventId ?? null,
+          input.status,
+          input.reason ?? null,
+        ],
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- replace process-local webhook dedup with durable Postgres-backed idempotency state when `PERSISTENCE_DRIVER=postgres`
- persist webhook audit rows for processed, duplicate, and rejected outcomes
- add Postgres integration regression coverage for durable replay protection and audit persistence
- harden PG test migrations against concurrent suite startup races

## Validation
- npm run lint
- npm run typecheck
- npm run build
- DATABASE_URL='postgresql://grantledger_app:grantledger_app@localhost:5432/grantledger_rls' npm run test:pg
- npm run quality:gate

Closes #121
