### PR TITLE
refactor(api): move subscription in-memory deps into bootstrap module

### DIFF
--- a/apps/api/src/bootstrap/composition-root.ts
+++ b/apps/api/src/bootstrap/composition-root.ts
@@ -41,10 +41,11 @@ import {
   type WebhookHandlers,
 } from "../handlers/webhook.js";
 import {
-  createInMemorySubscriptionUseCaseDeps,
   createSubscriptionHandlers,
   type SubscriptionHandlers,
 } from "../handlers/subscription.js";
+import { createInMemorySubscriptionUseCaseDeps } from "./subscription-deps.js";
+
 
 class FakePaymentProvider implements PaymentProvider {
   public readonly name = "fake" as const;

--- a/apps/api/src/bootstrap/subscription-deps.ts
+++ b/apps/api/src/bootstrap/subscription-deps.ts
@@ -1,0 +1,58 @@
+import {
+  createInMemoryAsyncIdempotencyStore,
+  type SubscriptionAuditLogger,
+  type SubscriptionEventPublisher,
+  type SubscriptionIdempotencyStore,
+  type SubscriptionRepository,
+  type SubscriptionUseCaseDeps,
+} from "@grantledger/application";
+import type {
+  Subscription,
+  SubscriptionAuditEvent,
+  SubscriptionDomainEvent,
+} from "@grantledger/contracts";
+import { emitStructuredLog } from "@grantledger/shared";
+
+class InMemorySubscriptionRepository implements SubscriptionRepository {
+  private readonly store = new Map<string, Subscription>();
+
+  async findById(subscriptionId: string): Promise<Subscription | null> {
+    return this.store.get(subscriptionId) ?? null;
+  }
+
+  async create(subscription: Subscription): Promise<void> {
+    this.store.set(subscription.id, subscription);
+  }
+
+  async save(subscription: Subscription): Promise<void> {
+    this.store.set(subscription.id, subscription);
+  }
+}
+
+class ConsoleSubscriptionEventPublisher implements SubscriptionEventPublisher {
+  async publish(event: SubscriptionDomainEvent): Promise<void> {
+    emitStructuredLog({
+      type: "domain_event",
+      payload: event as unknown as Record<string, unknown>,
+    });
+  }
+}
+
+class ConsoleSubscriptionAuditLogger implements SubscriptionAuditLogger {
+  async log(event: SubscriptionAuditEvent): Promise<void> {
+    emitStructuredLog({
+      type: "audit_event",
+      payload: event as unknown as Record<string, unknown>,
+    });
+  }
+}
+
+export function createInMemorySubscriptionUseCaseDeps(): SubscriptionUseCaseDeps {
+  return {
+    repository: new InMemorySubscriptionRepository(),
+    idempotencyStore:
+      createInMemoryAsyncIdempotencyStore<Subscription>() satisfies SubscriptionIdempotencyStore,
+    eventPublisher: new ConsoleSubscriptionEventPublisher(),
+    auditLogger: new ConsoleSubscriptionAuditLogger(),
+  };
+}

--- a/apps/api/src/handlers/subscription.ts
+++ b/apps/api/src/handlers/subscription.ts
@@ -3,26 +3,20 @@ import {
   BadRequestError,
   cancelSubscriptionAtPeriodEnd,
   cancelSubscriptionNow,
-  createInMemoryAsyncIdempotencyStore,
   createSubscription,
   downgradeSubscription,
-  type SubscriptionAuditLogger,
-  type SubscriptionEventPublisher,
-  type SubscriptionIdempotencyStore,
-  type SubscriptionRepository,
   type SubscriptionUseCaseDeps,
   upgradeSubscription,
 } from "@grantledger/application";
+
 import type {
   CancelSubscriptionAtPeriodEndCommandInput,
   CancelSubscriptionNowCommandInput,
   CreateSubscriptionCommandInput,
   DowngradeSubscriptionCommandInput,
-  Subscription,
-  SubscriptionAuditEvent,
-  SubscriptionDomainEvent,
   UpgradeSubscriptionCommandInput,
 } from "@grantledger/contracts";
+
 import {
   upgradeSubscriptionCommandPayloadSchema,
   createSubscriptionCommandPayloadSchema,
@@ -32,49 +26,11 @@ import {
 } from "@grantledger/contracts";
 
 import { parseOrThrowBadRequest } from "../http/validation.js";
-import { emitStructuredLog, type Clock, type IdGenerator } from "@grantledger/shared";
+import { type Clock, type IdGenerator } from "@grantledger/shared";
 
 import { getHeader } from "../http/headers.js";
 import type { ApiResponse, Headers } from "../http/types.js";
 import { resolveContextFromHeaders } from "./auth.js";
-
-class InMemorySubscriptionRepository implements SubscriptionRepository {
-  private readonly store = new Map<string, Subscription>();
-
-  async findById(subscriptionId: string): Promise<Subscription | null> {
-    return this.store.get(subscriptionId) ?? null;
-  }
-
-  async create(subscription: Subscription): Promise<void> {
-    this.store.set(subscription.id, subscription);
-  }
-
-  async save(subscription: Subscription): Promise<void> {
-    this.store.set(subscription.id, subscription);
-  }
-}
-
-class ConsoleSubscriptionEventPublisher implements SubscriptionEventPublisher {
-  async publish(event: SubscriptionDomainEvent): Promise<void> {
-    emitStructuredLog({ type: "domain_event", payload: event as unknown as Record<string, unknown> });
-  }
-}
-
-class ConsoleSubscriptionAuditLogger implements SubscriptionAuditLogger {
-  async log(event: SubscriptionAuditEvent): Promise<void> {
-    emitStructuredLog({ type: "audit_event", payload: event as unknown as Record<string, unknown> });
-  }
-}
-
-export function createInMemorySubscriptionUseCaseDeps(): SubscriptionUseCaseDeps {
-  return {
-    repository: new InMemorySubscriptionRepository(),
-    idempotencyStore:
-      createInMemoryAsyncIdempotencyStore<Subscription>() satisfies SubscriptionIdempotencyStore,
-    eventPublisher: new ConsoleSubscriptionEventPublisher(),
-    auditLogger: new ConsoleSubscriptionAuditLogger(),
-  };
-}
 
 export interface SubscriptionHandlersDeps {
   subscriptionUseCases: SubscriptionUseCaseDeps;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,6 +10,8 @@ export {
   type InvoiceHandlersDeps,
 } from "./handlers/invoice.js";
 export * from "./handlers/subscription.js";
+export { createInMemorySubscriptionUseCaseDeps } from "./bootstrap/subscription-deps.js";
+
 export * from "./http/errors.js";
 export * from "./http/headers.js";
 export * from "./http/types.js";


### PR DESCRIPTION
## Summary
- move subscription in-memory runtime deps into a dedicated bootstrap module
- keep subscription handlers focused on transport behavior
- preserve public exports while improving runtime composition boundaries

## Validation
- npm run build
- npm run test
- npm run quality:gate
- DATABASE_URL='postgresql://grantledger_app:grantledger_app@localhost:5432/grantledger_rls' npm run test:pg

Closes #127
