### PR TITLE
chore(repo): finalise canonical repository slug

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Architecture Decisions (ADRs)
-    url: https://github.com/gabe-dalmolin/grantledger-platform/tree/main/docs/adr
+    url: https://github.com/gabedalmolin/grantledger-platform/tree/main/docs/adr
     about: Check existing ADRs before opening architecture issues

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GrantLedger Platform
 
-[![CI](https://github.com/gabe-dalmolin/grantledger-platform/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gabe-dalmolin/grantledger-platform/actions/workflows/ci.yml)
+[![CI](https://github.com/gabedalmolin/grantledger-platform/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gabedalmolin/grantledger-platform/actions/workflows/ci.yml)
 
 GrantLedger is a multi-tenant SaaS billing platform built to make change-safe billing workflows easier to reason about, validate, and evolve.
 
@@ -329,7 +329,7 @@ Architecture changes follow an issue-driven stream (`ARCH-*`) with mandatory doc
 
 ## Project Links
 
-- Repository: [gabe-dalmolin/grantledger-platform](https://github.com/gabe-dalmolin/grantledger-platform)
+- Repository: [gabedalmolin/grantledger-platform](https://github.com/gabedalmolin/grantledger-platform)
 - Project board: [GitHub Project #6](https://github.com/users/john-dalmolin/projects/6)
 
 ## Acknowledgments

--- a/scripts/delivery-bootstrap.sh
+++ b/scripts/delivery-bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="${REPO:-gabe-dalmolin/grantledger-platform}"
+REPO="${REPO:-gabedalmolin/grantledger-platform}"
 PROJECT_NUMBER="${PROJECT_NUMBER:-6}"
 PROJECT_OWNER="${PROJECT_OWNER:-john-dalmolin}"
 BASE_BRANCH="${BASE_BRANCH:-main}"

--- a/scripts/delivery-closeout.sh
+++ b/scripts/delivery-closeout.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="${REPO:-gabe-dalmolin/grantledger-platform}"
+REPO="${REPO:-gabedalmolin/grantledger-platform}"
 PROJECT_NUMBER="${PROJECT_NUMBER:-6}"
 PROJECT_OWNER="${PROJECT_OWNER:-john-dalmolin}"
 BASE_BRANCH="${BASE_BRANCH:-main}"
@@ -29,7 +29,7 @@ Required:
 
 Optional:
   --issue <number>             Issue number (auto-detected from "Closes #N" when omitted)
-  --repo <slug>                Repository slug (default: gabe-dalmolin/grantledger-platform)
+  --repo <slug>                Repository slug (default: gabedalmolin/grantledger-platform)
   --project <number>           Project number (default: 6)
   --owner <owner>              Project owner (default: john-dalmolin, fallback @me)
   --base <branch>              Base branch to sync locally (default: main)

--- a/scripts/pr-metadata-sync.sh
+++ b/scripts/pr-metadata-sync.sh
@@ -11,7 +11,7 @@ Required:
   --issue <number>
 
 Optional (defaults):
-  --repo <slug>        gabe-dalmolin/grantledger-platform
+  --repo <slug>        gabedalmolin/grantledger-platform
   --owner <owner>      john-dalmolin
   --project <number>   6
   --milestone <name>   Architecture Improve
@@ -117,7 +117,7 @@ project_add_item() {
   fail "Unable to add PR item to project #$PROJECT_NUMBER"
 }
 
-REPO="gabe-dalmolin/grantledger-platform"
+REPO="gabedalmolin/grantledger-platform"
 OWNER="john-dalmolin"
 PROJECT_NUMBER="6"
 MILESTONE="Architecture Improve"


### PR DESCRIPTION
## Summary
- replace the intermediate hyphenated owner variant with the canonical GitHub repository slug
- keep README links, badge URLs, issue template links, and delivery script defaults aligned
- avoid changing project-owner automation in this PR because that needs a dedicated follow-up

## Validation
- bash -n scripts/delivery-bootstrap.sh
- bash -n scripts/delivery-closeout.sh
- bash -n scripts/pr-metadata-sync.sh
- verified no remaining references to the hyphenated owner variant in README, issue templates, or delivery scripts

Closes #135
