### PR TITLE
chore(scripts): detect GitHub owner and assignee dynamically

### DIFF
--- a/scripts/delivery-bootstrap.sh
+++ b/scripts/delivery-bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO="${REPO:-gabedalmolin/grantledger-platform}"
 PROJECT_NUMBER="${PROJECT_NUMBER:-6}"
-PROJECT_OWNER="${PROJECT_OWNER:-john-dalmolin}"
+PROJECT_OWNER="${PROJECT_OWNER:-@me}"
 BASE_BRANCH="${BASE_BRANCH:-main}"
 DEFAULT_LABEL="${DEFAULT_LABEL:-Architecture Hardening}"
 RUN_GATES=1

--- a/scripts/delivery-closeout.sh
+++ b/scripts/delivery-closeout.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO="${REPO:-gabedalmolin/grantledger-platform}"
 PROJECT_NUMBER="${PROJECT_NUMBER:-6}"
-PROJECT_OWNER="${PROJECT_OWNER:-john-dalmolin}"
+PROJECT_OWNER="${PROJECT_OWNER:-@me}"
 BASE_BRANCH="${BASE_BRANCH:-main}"
 MERGE_METHOD="${MERGE_METHOD:-squash}" # squash|merge|rebase|none
 WATCH_CHECKS=1
@@ -31,7 +31,7 @@ Optional:
   --issue <number>             Issue number (auto-detected from "Closes #N" when omitted)
   --repo <slug>                Repository slug (default: gabedalmolin/grantledger-platform)
   --project <number>           Project number (default: 6)
-  --owner <owner>              Project owner (default: john-dalmolin, fallback @me)
+  --owner <owner>              Project owner (default: @me)
   --base <branch>              Base branch to sync locally (default: main)
   --merge-method <value>       squash|merge|rebase|none (default: squash)
   --no-watch-checks            Skip waiting for PR checks

--- a/scripts/pr-metadata-sync.sh
+++ b/scripts/pr-metadata-sync.sh
@@ -12,10 +12,10 @@ Required:
 
 Optional (defaults):
   --repo <slug>        gabedalmolin/grantledger-platform
-  --owner <owner>      john-dalmolin
+  --owner <owner>      @me
   --project <number>   6
   --milestone <name>   Architecture Improve
-  --assignee <login>   john-dalmolin
+  --assignee <login>   authenticated GitHub user
   --label <name>       Architecture Hardening
   --status <value>     Review
   --priority <value>   P1
@@ -118,10 +118,10 @@ project_add_item() {
 }
 
 REPO="gabedalmolin/grantledger-platform"
-OWNER="john-dalmolin"
+OWNER="@me"
 PROJECT_NUMBER="6"
 MILESTONE="Architecture Improve"
-ASSIGNEE="john-dalmolin"
+ASSIGNEE=""
 LABEL="Architecture Hardening"
 STATUS_VALUE="Review"
 PRIORITY_VALUE="P1"
@@ -208,6 +208,11 @@ done
 for cmd in gh jq rg tr mktemp; do
   command -v "$cmd" >/dev/null 2>&1 || fail "Required command not found: $cmd"
 done
+
+if [ -z "$ASSIGNEE" ]; then
+  ASSIGNEE=$(gh api user -q .login)
+  [ -n "$ASSIGNEE" ] || fail "Could not resolve authenticated GitHub user login"
+fi
 
 PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
 


### PR DESCRIPTION
## Summary
- default delivery automation project-owner operations to `@me`
- resolve the GitHub assignee login dynamically in PR metadata sync
- keep the existing delivery workflow intact while making it resilient to owner renames or repository transfers

## Validation
- bash -n scripts/delivery-bootstrap.sh
- bash -n scripts/delivery-closeout.sh
- bash -n scripts/pr-metadata-sync.sh
- gh api user -q .login

Closes #137
