### PR TITLE
chore(application): prune unused catalog surface

### DIFF
--- a/packages/application/src/catalog.ts
+++ b/packages/application/src/catalog.ts
@@ -158,20 +158,3 @@ export async function assertVersionNotCriticalMutated(
 ): Promise<void> {
   assertPublishedVersionImmutable(current);
 }
-
-export interface PlanCatalogRepository {
-  createPlan(input: CreatePlanInput): Promise<Plan>;
-  getPlanById(planId: string): Promise<Plan | null>;
-  listPlans(): Promise<Plan[]>;
-  createPlanVersion(input: CreatePlanVersionInput): Promise<PlanVersion>;
-  getPlanVersion(
-    planId: string,
-    versionId: string,
-  ): Promise<PlanVersion | null>;
-  listPlanVersions(planId: string): Promise<PlanVersion[]>;
-  savePlanVersion(planVersion: PlanVersion): Promise<void>;
-}
-
-export interface CatalogAuditLogger {
-  log(event: CatalogAuditEvent): Promise<void>;
-}

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./errors.js";
-export * from "./catalog.js";
 export * from "./auth-context.js";
 export * from "./idempotency.js";
 export * from "./checkout.js";


### PR DESCRIPTION
## Summary
- remove the unused `catalog` barrel export from `@grantledger/application`
- remove duplicated interface declarations from `packages/application/src/catalog.ts`
- keep the internal catalog module unexposed until it has real runtime integration

## Notes
- `apps/admin` was reviewed during the audit but deliberately left untouched because it looks like a product placeholder rather than low-risk dead code

## Validation
- npm run typecheck
- npm run build
- npm run test

Closes #139
