### PR TITLE
chore(arch-027): improve workspace DX and remove build-artifact coupling

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/admin')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests apps/admin/src"
   },
   "dependencies": {
     "@grantledger/shared": "0.1.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/api')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests apps/api/src"
   },
   "dependencies": {
     "@grantledger/application": "0.1.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/worker')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests apps/worker/src"
   },
   "dependencies": {
     "@grantledger/shared": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^8.57.1",
         "prettier": "^3.5.3",
+        "tsx": "^4.21.0",
         "typescript": "^5.8.2",
         "vite-tsconfig-paths": "^6.1.1",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "yaml": "^2.8.2"
       },
       "engines": {
         "node": ">=22 <23",
@@ -3231,6 +3233,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4785,6 +4800,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5422,6 +5447,26 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5852,8 +5897,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc -b",
     "test:watch": "vitest",
-    "quality:gate": "npm run lint && npm run build && npm run typecheck && npm run openapi:check && npm run test:coverage",
+    "quality:gate": "npm run lint && npm run build && npm run openapi:check && npm run test:coverage",
     "test:workspaces": "npm run --workspaces --if-present test",
     "test:pg": "node ./scripts/verify-pg-test-env.mjs && RUN_PG_TESTS=1 vitest run packages/infra-postgres/src",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "db:migrate": "node ./scripts/db-migrate.mjs",
-    "openapi:generate": "node ./scripts/generate-openapi.mjs",
+    "openapi:generate": "tsx ./scripts/generate-openapi.ts",
     "openapi:validate": "redocly lint docs/openapi/openapi.json --config  .redocly.yaml",
     "openapi:drift:check": "git diff --exit-code -- docs/openapi/openapi.json",
     "openapi:check": "npm run openapi:generate && npm run openapi:validate && npm run openapi:drift:check"
@@ -37,8 +37,10 @@
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^8.57.1",
     "prettier": "^3.5.3",
+    "tsx": "^4.21.0",
     "typescript": "^5.8.2",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "yaml": "^2.8.2"
   }
 }

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/application')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests packages/application/src"
   },
   "dependencies": {
     "@grantledger/shared": "0.1.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/contracts')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests packages/contracts/src"
   },
   "dependencies": {
     "@grantledger/shared": "0.1.0",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/domain')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests packages/domain/src"
   },
   "dependencies": {
     "@grantledger/shared": "0.1.0"

--- a/packages/infra-postgres/package.json
+++ b/packages/infra-postgres/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/infra-postgres')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests packages/infra-postgres/src"
   },
   "dependencies": {
     "@grantledger/application": "0.1.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "test": "node -e \"console.log('No tests yet: @grantledger/shared')\""
+    "test": "vitest run --root ../../ --config vitest.config.ts --passWithNoTests packages/shared/src"
   },
   "dependencies": {
     "luxon": "^3.7.2"

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -12,12 +12,9 @@ import {
   getInvoiceGenerationJobStatusResponseSchema,
   paymentWebhookEnvelopeSchema,
   paymentWebhookProcessResultSchema,
-} from "../packages/contracts/dist/schemas/index.js";
+} from "../packages/contracts/src/schemas/index.ts";
 
-const outPath = path.resolve(
-  process.cwd(),
-  "docs/openapi/openapi.json",
-);
+const outPath = path.resolve(process.cwd(), "docs/openapi/openapi.json");
 
 const CLIENT_ERROR_DESCRIPTIONS = {
   "400": "Bad Request",
@@ -70,7 +67,7 @@ const OPERATION_METADATA = {
   },
 };
 
-function enrichForLint(doc) {
+function enrichForLint(doc: Record<string, any>) {
   doc.info = {
     ...doc.info,
     license: doc.info?.license ?? {
@@ -81,9 +78,7 @@ function enrichForLint(doc) {
 
   doc.servers = doc.servers?.length
     ? doc.servers
-    : [
-      { url: "https://api.grantledger.com", description: "Production" },
-    ];
+    : [{ url: "https://api.grantledger.com", description: "Production" }];
 
   doc.components = doc.components ?? {};
   doc.components.securitySchemes = doc.components.securitySchemes ?? {};
@@ -94,8 +89,8 @@ function enrichForLint(doc) {
       bearerFormat: "JWT",
     };
 
-  for (const [path, methods] of Object.entries(OPERATION_METADATA)) {
-    const pathItem = doc.paths?.[path];
+  for (const [pathKey, methods] of Object.entries(OPERATION_METADATA)) {
+    const pathItem = doc.paths?.[pathKey];
     if (!pathItem) continue;
 
     for (const [method, meta] of Object.entries(methods)) {
@@ -109,7 +104,10 @@ function enrichForLint(doc) {
 
       for (const status of meta.clientErrors) {
         op.responses[status] ??= {
-          description: CLIENT_ERROR_DESCRIPTIONS[status] ?? "Client Error",
+          description:
+            CLIENT_ERROR_DESCRIPTIONS[
+              status as keyof typeof CLIENT_ERROR_DESCRIPTIONS
+            ] ?? "Client Error",
         };
       }
     }


### PR DESCRIPTION
## Summary
- align workspace test scripts with the monorepo test model
- generate OpenAPI from source contracts instead of built dist artifacts
- remove duplicate compilation work from the quality gate

## Validation
- npm run test:workspaces
- npm run openapi:check
- npm run quality:gate

Closes #144
