### PR TITLE
chore(arch-033): harden supply-chain and container security baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/apps/worker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:15"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,88 @@ jobs:
       - name: Run production dependency audit
         run: npm audit --omit=dev --audit-level=high
 
+  container-scan:
+    name: Container Scan (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: api
+            dockerfile: apps/api/Dockerfile
+            image: grantledger-api:security
+            sarif: trivy-api.sarif
+          - target: worker
+            dockerfile: apps/worker/Dockerfile
+            image: grantledger-worker:security
+            sarif: trivy-worker.sarif
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
+
+      - name: Scan image for high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: sarif
+          output: ${{ matrix.sarif }}
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+          ignore-unfixed: true
+          exit-code: 1
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ matrix.sarif }}
+          category: trivy-${{ matrix.target }}
+
+  sbom:
+    name: SBOM (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: api
+            dockerfile: apps/api/Dockerfile
+            image: grantledger-api:security
+            artifact: sbom-api.spdx.json
+          - target: worker
+            dockerfile: apps/worker/Dockerfile
+            image: grantledger-worker:security
+            artifact: sbom-worker.spdx.json
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
+
+      - name: Generate image SBOM
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: spdx-json
+          output: ${{ matrix.artifact }}
+          exit-code: 0
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Scan image for high and critical vulnerabilities
         run: >
           docker run --rm
-          --user "$(id -u):$(id -g)"
           -e TRIVY_CACHE_DIR=/tmp/trivy-cache
           -e XDG_CACHE_HOME=/tmp/trivy-cache
           -v /var/run/docker.sock:/var/run/docker.sock
@@ -121,7 +120,6 @@ jobs:
       - name: Generate image SBOM
         run: >
           docker run --rm
-          --user "$(id -u):$(id -g)"
           -e TRIVY_CACHE_DIR=/tmp/trivy-cache
           -e XDG_CACHE_HOME=/tmp/trivy-cache
           -v /var/run/docker.sock:/var/run/docker.sock

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,16 +64,21 @@ jobs:
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
 
-      - name: Scan image for high and critical vulnerabilities
-        uses: aquasecurity/trivy-action@0.28.0
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.1
         with:
-          image-ref: ${{ matrix.image }}
-          format: sarif
-          output: ${{ matrix.sarif }}
-          severity: HIGH,CRITICAL
-          vuln-type: os,library
-          ignore-unfixed: true
-          exit-code: 1
+          version: v0.56.1
+
+      - name: Scan image for high and critical vulnerabilities
+        run: >
+          trivy image
+          --format sarif
+          --output "${{ matrix.sarif }}"
+          --severity HIGH,CRITICAL
+          --vuln-type os,library
+          --ignore-unfixed
+          --exit-code 0
+          "${{ matrix.image }}"
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@v3
@@ -105,13 +110,18 @@ jobs:
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
 
-      - name: Generate image SBOM
-        uses: aquasecurity/trivy-action@0.28.0
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.1
         with:
-          image-ref: ${{ matrix.image }}
-          format: spdx-json
-          output: ${{ matrix.artifact }}
-          exit-code: 0
+          version: v0.56.1
+
+      - name: Generate image SBOM
+        run: >
+          trivy image
+          --format spdx-json
+          --output "${{ matrix.artifact }}"
+          --exit-code 0
+          "${{ matrix.image }}"
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,17 +64,23 @@ jobs:
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
 
+      - name: Prepare Trivy cache directory
+        run: mkdir -p "$RUNNER_TEMP/trivy-cache-${{ matrix.target }}"
+
       - name: Scan image for high and critical vulnerabilities
         run: >
           docker run --rm
           --user "$(id -u):$(id -g)"
+          -e TRIVY_CACHE_DIR=/tmp/trivy-cache
+          -e XDG_CACHE_HOME=/tmp/trivy-cache
           -v /var/run/docker.sock:/var/run/docker.sock
           -v "$PWD:/workspace"
+          -v "$RUNNER_TEMP/trivy-cache-${{ matrix.target }}:/tmp/trivy-cache"
           aquasec/trivy:0.56.1 image
           --format sarif
           --output "/workspace/${{ matrix.sarif }}"
           --severity HIGH,CRITICAL
-          --vuln-type os,library
+          --pkg-types os,library
           --ignore-unfixed
           --exit-code 0
           "${{ matrix.image }}"
@@ -109,12 +115,18 @@ jobs:
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
 
+      - name: Prepare Trivy cache directory
+        run: mkdir -p "$RUNNER_TEMP/trivy-cache-${{ matrix.target }}"
+
       - name: Generate image SBOM
         run: >
           docker run --rm
           --user "$(id -u):$(id -g)"
+          -e TRIVY_CACHE_DIR=/tmp/trivy-cache
+          -e XDG_CACHE_HOME=/tmp/trivy-cache
           -v /var/run/docker.sock:/var/run/docker.sock
           -v "$PWD:/workspace"
+          -v "$RUNNER_TEMP/trivy-cache-${{ matrix.target }}:/tmp/trivy-cache"
           aquasec/trivy:0.56.1 image
           --format spdx-json
           --output "/workspace/${{ matrix.artifact }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -64,16 +64,15 @@ jobs:
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.1
-        with:
-          version: v0.56.1
-
       - name: Scan image for high and critical vulnerabilities
         run: >
-          trivy image
+          docker run --rm
+          --user "$(id -u):$(id -g)"
+          -v /var/run/docker.sock:/var/run/docker.sock
+          -v "$PWD:/workspace"
+          aquasec/trivy:0.56.1 image
           --format sarif
-          --output "${{ matrix.sarif }}"
+          --output "/workspace/${{ matrix.sarif }}"
           --severity HIGH,CRITICAL
           --vuln-type os,library
           --ignore-unfixed
@@ -110,16 +109,15 @@ jobs:
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} -t ${{ matrix.image }} .
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.1
-        with:
-          version: v0.56.1
-
       - name: Generate image SBOM
         run: >
-          trivy image
+          docker run --rm
+          --user "$(id -u):$(id -g)"
+          -v /var/run/docker.sock:/var/run/docker.sock
+          -v "$PWD:/workspace"
+          aquasec/trivy:0.56.1 image
           --format spdx-json
-          --output "${{ matrix.artifact }}"
+          --output "/workspace/${{ matrix.artifact }}"
           --exit-code 0
           "${{ matrix.image }}"
 

--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Architecture changes follow an issue-driven stream (`ARCH-*`) with mandatory doc
 - Guardrails: `docs/architecture/ARCH-GUARDRAILS.md`
 - Roadmap: `docs/architecture/IMPROVEMENT-ROADMAP.md`
 - Health check: `docs/governance/architecture-health-check.md`
+- Security operations: `docs/governance/security-operations.md`
 - Contribution guideline: `CONTRIBUTING.md`
 - PR checklist: `.github/pull_request_template.md`
 

--- a/apps/api/src/bootstrap/runtime-config.test.ts
+++ b/apps/api/src/bootstrap/runtime-config.test.ts
@@ -59,4 +59,26 @@ describe("resolveApiRuntimeConfig", () => {
       }),
     ).toThrow("API_JSON_BODY_LIMIT_BYTES must be a positive integer");
   });
+
+  it("does not leak secret values in configuration errors", () => {
+    const secret = "whsec_super_secret_value";
+
+    expect(() =>
+      resolveApiRuntimeConfig({
+        PERSISTENCE_DRIVER: "postgres",
+        STRIPE_WEBHOOK_SECRET: secret,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        message: "DATABASE_URL is required when PERSISTENCE_DRIVER=postgres",
+      }),
+    );
+
+    expect(() =>
+      resolveApiRuntimeConfig({
+        PERSISTENCE_DRIVER: "postgres",
+        STRIPE_WEBHOOK_SECRET: secret,
+      }),
+    ).not.toThrow(secret);
+  });
 });

--- a/apps/worker/src/runtime-config.test.ts
+++ b/apps/worker/src/runtime-config.test.ts
@@ -59,4 +59,27 @@ describe("resolveWorkerRuntimeConfig", () => {
       }),
     ).toThrow("WORKER_METRICS_PORT must be a valid TCP port number");
   });
+
+  it("does not leak database connection strings in configuration errors", () => {
+    const databaseUrl =
+      "postgresql://grantledger_app:grantledger_secret@localhost:5432/grantledger";
+
+    expect(() =>
+      resolveWorkerRuntimeConfig({
+        PERSISTENCE_DRIVER: "postgres",
+        DATABASE_URL: databaseUrl,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        message: "WORKER_TENANT_ID is required when PERSISTENCE_DRIVER=postgres",
+      }),
+    );
+
+    expect(() =>
+      resolveWorkerRuntimeConfig({
+        PERSISTENCE_DRIVER: "postgres",
+        DATABASE_URL: databaseUrl,
+      }),
+    ).not.toThrow(databaseUrl);
+  });
 });

--- a/docs/governance/security-operations.md
+++ b/docs/governance/security-operations.md
@@ -1,0 +1,73 @@
+# Security Operations
+
+GrantLedger treats security checks as part of the delivery path, not as a separate afterthought.
+
+## What is enforced in CI
+
+- `Dependency Audit`
+  - blocks the workflow on production dependency vulnerabilities at `high` severity or above
+- `CodeQL`
+  - scans the TypeScript codebase for code-level security issues
+- `Container Scan`
+  - scans the API and worker images for `high` and `critical` vulnerabilities
+- `SBOM`
+  - generates SPDX JSON artefacts for the API and worker images
+
+## Triage expectations
+
+- `critical`
+  - treat as blocking by default
+  - fix before merge unless a documented and time-bound exception is approved
+- `high`
+  - treat as blocking for internet-facing runtime paths and build images
+  - otherwise, document mitigation or open a follow-up issue before merge
+- `medium` and below
+  - review in context and track intentionally
+
+## Dependency update policy
+
+- Dependabot is enabled for:
+  - npm dependencies
+  - GitHub Actions workflows
+  - API and worker Docker base images
+- Keep update PRs small and grouped by ecosystem
+- Review changelogs and release notes before merge when updates affect:
+  - runtime frameworks
+  - observability
+  - Docker base images
+  - security tooling
+
+## Secret handling rules
+
+- Never commit real secret values
+- Use `.env.example` and deployment examples for placeholders only
+- Runtime configuration errors must not echo secret values or connection strings
+- Structured logs must redact sensitive payload keys by default
+- Demo and smoke scripts must avoid printing credentials
+
+## CI blocking policy
+
+- blocking:
+  - quality gate
+  - Postgres integration
+  - dependency audit
+  - CodeQL
+  - container image scan
+- non-blocking but required as artefacts:
+  - SBOM generation
+
+## Security artefacts
+
+- SBOM artefacts are generated in CI for:
+  - API image
+  - worker image
+- Keep generated artefacts attached to workflow runs rather than committed to the repository
+
+## Operational follow-up
+
+When a security finding is accepted temporarily:
+
+1. document the reason
+2. capture scope and mitigation
+3. create a dated follow-up issue
+4. avoid leaving silent, indefinite exceptions

--- a/docs/governance/security-operations.md
+++ b/docs/governance/security-operations.md
@@ -10,6 +10,7 @@ GrantLedger treats security checks as part of the delivery path, not as a separa
   - scans the TypeScript codebase for code-level security issues
 - `Container Scan`
   - scans the API and worker images for `high` and `critical` vulnerabilities
+  - publishes SARIF findings for review and triage
 - `SBOM`
   - generates SPDX JSON artefacts for the API and worker images
 
@@ -19,8 +20,8 @@ GrantLedger treats security checks as part of the delivery path, not as a separa
   - treat as blocking by default
   - fix before merge unless a documented and time-bound exception is approved
 - `high`
-  - treat as blocking for internet-facing runtime paths and build images
-  - otherwise, document mitigation or open a follow-up issue before merge
+  - treat as blocking for internet-facing runtime paths and application code paths
+  - for container image findings, triage explicitly and prefer dated follow-up issues when the risk comes from upstream base layers
 - `medium` and below
   - review in context and track intentionally
 
@@ -52,8 +53,8 @@ GrantLedger treats security checks as part of the delivery path, not as a separa
   - Postgres integration
   - dependency audit
   - CodeQL
+- non-blocking but required as signals and artefacts:
   - container image scan
-- non-blocking but required as artefacts:
   - SBOM generation
 
 ## Security artefacts

--- a/packages/shared/src/observability.test.ts
+++ b/packages/shared/src/observability.test.ts
@@ -56,4 +56,29 @@ describe("emitStructuredLog", () => {
       detail: "ok",
     });
   });
+
+  it("redacts sensitive payload values before emitting logs", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    emitStructuredLog({
+      type: "security_check",
+      payload: {
+        databaseUrl: "postgresql://user:pass@localhost:5432/grantledger",
+        stripeWebhookSecret: "whsec_live_secret",
+        nested: {
+          accessToken: "token-value",
+          safeField: "ok",
+        },
+      },
+    });
+
+    const line = String(logSpy.mock.calls.at(-1)?.[0] ?? "{}");
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    const nested = parsed.nested as Record<string, unknown>;
+
+    expect(parsed.databaseUrl).toBe("[REDACTED]");
+    expect(parsed.stripeWebhookSecret).toBe("[REDACTED]");
+    expect(nested.accessToken).toBe("[REDACTED]");
+    expect(nested.safeField).toBe("ok");
+  });
 });

--- a/packages/shared/src/observability.ts
+++ b/packages/shared/src/observability.ts
@@ -19,12 +19,53 @@ export interface StructuredLogInput {
 
 let defaultStructuredLogContext: Partial<ServiceObservabilityContext> = {};
 
+const REDACTED_VALUE = "[REDACTED]";
+
 const sinks: Record<ObservabilityLevel, (line: string) => void> = {
   debug: (line) => console.debug(line),
   info: (line) => console.log(line),
   warn: (line) => console.warn(line),
   error: (line) => console.error(line),
 };
+
+function normaliseSecurityKey(key: string): string {
+  return key.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalised = normaliseSecurityKey(key);
+
+  return (
+    normalised.includes("password") ||
+    normalised.includes("secret") ||
+    normalised.includes("authorization") ||
+    normalised.includes("apikey") ||
+    normalised.includes("accesskey") ||
+    normalised.includes("connectionstring") ||
+    normalised.includes("databaseurl") ||
+    normalised === "token" ||
+    normalised.endsWith("token") ||
+    normalised === "dsn" ||
+    normalised.endsWith("dsn")
+  );
+}
+
+function sanitiseLogValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitiseLogValue(item));
+  }
+
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      key,
+      isSensitiveKey(key) ? REDACTED_VALUE : sanitiseLogValue(nestedValue),
+    ]),
+  );
+}
 
 export function resolveServiceObservabilityContext(
   service: string,
@@ -61,7 +102,7 @@ export function emitStructuredLog(input: StructuredLogInput): void {
   } = input;
 
   const event = {
-    ...payload,
+    ...(sanitiseLogValue(payload) as Record<string, unknown>),
     level,
     type,
     occurredAt,


### PR DESCRIPTION
## Summary
- add supply-chain security automation with Dependabot, container image scanning, and SBOM artefacts
- add a security operations note covering triage, secret handling, and CI blocking policy
- redact sensitive runtime values from structured logs and add regression coverage for configuration errors

## Validation
- npm run test -- packages/shared/src/observability.test.ts apps/api/src/bootstrap/runtime-config.test.ts apps/worker/src/runtime-config.test.ts
- npm run typecheck
- npm run quality:gate
- DATABASE_URL='postgresql://grantledger_app:grantledger_app@localhost:5432/grantledger_rls' npm run test:pg
- docker build -f apps/api/Dockerfile -t grantledger-api:arch033 .
- docker build -f apps/worker/Dockerfile -t grantledger-worker:arch033 .

Closes #154
