### PR TITLE
docs(arch-034): sync governance and architecture narrative through ARCH-033

### DIFF
--- a/docs/architecture/ARCH-TRACKER.md
+++ b/docs/architecture/ARCH-TRACKER.md
@@ -2,51 +2,55 @@
 
 ## Objective
 
-Deliver structural improvements without blocking feature delivery.
+Track architecture hardening as a deliberate delivery stream, preserve an auditable record of structural decisions, and keep governance documents aligned with the actual platform baseline.
 
 ## Canonical References
 
 - Guardrails: `docs/architecture/ARCH-GUARDRAILS.md`
 - Roadmap: `docs/architecture/IMPROVEMENT-ROADMAP.md`
 - Boundary ADR: `docs/adr/ADR-005-domain-vs-application-boundary.md`
+- Architecture health check: `docs/governance/architecture-health-check.md`
+
+## Baseline Summary
+
+The ARCH hardening baseline is complete through `ARCH-033`.
+
+That baseline now includes:
+
+- clear domain vs application boundaries;
+- schema-first contracts and OpenAPI generation;
+- timezone-safe datetime handling and standardised error mapping;
+- generic idempotency orchestration and durable webhook/invoice persistence;
+- executable API and worker runtimes with health, readiness, and metrics;
+- self-hosted deployment validation and guided demo coverage;
+- supply-chain and container security automation.
 
 ## Scope
 
-- Define and enforce Domain vs Application boundaries
-- Modularize monolithic `index.ts` files
-- Adopt schema-first validation with Zod
-- Standardize date/time strategy with timezone support
-- Standardize exception-to-API response mapping
-- Introduce generic idempotency executor
-- Introduce i18n foundation (`en_US` baseline)
-- Finalize hardening for idempotency states, dedupe extraction, and style guidance
-- Roll out async idempotent invoice generation across application, API, and worker
+The ARCH stream covered the following structural concerns:
+
+- define and enforce Domain vs Application boundaries;
+- modularise monolithic package surfaces and hotspots;
+- adopt schema-first validation with Zod;
+- standardise date/time strategy with timezone support;
+- standardise exception-to-API response mapping;
+- introduce generic idempotency execution and state management;
+- introduce i18n and shared platform foundations;
+- roll out async idempotent invoice orchestration across API, application, worker, and Postgres infrastructure;
+- harden bootstrap, runtime, observability, self-hosted deployment, and supply-chain baselines.
 
 ## Out of Scope
 
-- Business feature expansion unrelated to architecture hardening
+- unrelated business feature expansion;
+- UI/admin product work;
+- cloud-vendor-specific deployment strategy before the self-hosted baseline.
 
 ## Execution Strategy
 
 - Keep architecture changes incremental and reviewable.
-- Run in parallel with feature delivery using controlled WIP.
-- Limit active architecture work to one child issue at a time.
-
-## Required Update Timing (Always)
-
-### Start of ARCH issue (branch/issue opened)
-
-- Update this tracker with `IN_PROGRESS`, issue link, and branch name.
-- Update `IMPROVEMENT-ROADMAP.md` with focus and dependencies.
-- If a new architectural decision is needed, create/update ADR draft.
-- If no ADR change is needed, register: `No ADR change required`.
-
-### End of ARCH issue (before merge)
-
-- Update this tracker with `DONE`, PR link, and merged SHA.
-- Update `IMPROVEMENT-ROADMAP.md` with next step and residual risks.
-- Finalize ADR changes (when applicable).
-- Confirm PR checklist includes all ARCH governance items.
+- Preserve a stable public surface while improving internal structure.
+- Open a new ARCH issue only when there is a concrete structural risk or leverage opportunity.
+- Keep governance artefacts synchronized with delivered code, not aspirational state.
 
 ## Child Issues
 
@@ -56,7 +60,7 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `88787d7`
   - Notes: Added ADR-005 and baseline architecture guardrails/tracker.
 
-- [x] ARCH-002 - Modularize monolithic `index.ts`
+- [x] ARCH-002 - Modularise monolithic `index.ts`
   - Status: DONE
   - PR: `#32`
   - Merge SHA: `4cad15d`
@@ -78,14 +82,14 @@ Deliver structural improvements without blocking feature delivery.
   - Merge SHA: `46e6804`
   - Notes: Strict ISO-8601 datetime with explicit timezone offset, Luxon shared utilities, and critical Date migration.
 
-- [x] ARCH-005 - Standard error model + centralized API mapping
+- [x] ARCH-005 - Standard error model + centralised API mapping
   - Status: DONE
   - Issue: `#39`
   - Branch: `chore/arch-005-error-model-api-mapper`
   - PR: `#40`
   - Merge SHA: `b72ef69484dc898cc90d3feef4411b9e8e1914d6`
-  - Notes: AppError base + centralized mapper + auth/checkout/subscription adoption + Vitest coverage delivered.
-  - Residual risks: Remaining modules outside safe slice still use legacy/local mapping and should migrate in ARCH-006.
+  - Notes: AppError base + centralised mapper + auth/checkout/subscription adoption + Vitest coverage delivered.
+  - Residual risks: Remaining modules outside the initial slice migrated later in the ARCH stream.
 
 - [x] ARCH-006 - Generic idempotency executor
   - Status: DONE
@@ -93,8 +97,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-006-generic-idempotency-executor`
   - PR: `#43`
   - Merge SHA: `0706202f196d3c7969d39bc79e80a6e7d3cfe4aa`
-  - Notes: Implemented generic async idempotency executor, migrated subscription and auth flows, and adopted key-based webhook dedup through shared foundation.
-  - Residual risks: Payload-hash conflict detection for webhook flows remains intentionally out of scope in this stage.
+  - Notes: Implemented generic async idempotency executor, migrated subscription/auth flows, and adopted key-based webhook dedupe through shared foundations.
 
 - [x] ARCH-007 - i18n foundation (`en_US`)
   - Status: DONE
@@ -102,15 +105,15 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-007-i18n-foundation`
   - PR: `#46`
   - Merge SHA: `64e2d3d3b43943459944b36dc52af2df039a5724`
-  - Notes: Introduced i18n foundation with en-US baseline and API integration through shared translator.
+  - Notes: Introduced i18n foundation with en-US baseline and API integration through shared translation helpers.
 
-- [x] ARCH-008 - Final hardening for idempotency states, shared dedupe, and style guideline
+- [x] ARCH-008 - Final hardening for idempotency states, shared dedupe, and style guidance
   - Status: DONE
   - Issue: `#50`
   - Branch: `chore/arch-008-final-hardening`
   - PR: `#49`
   - Merge SHA: `bef4fbc2eca25f136871109d09168293923f46ae`
-  - Notes: Introduce stateful idempotency (`processing/completed/failed`), extract shared idempotency/error helpers, and formalize classes vs functions guideline.
+  - Notes: Introduced stateful idempotency, extracted shared helpers, and formalised classes vs functions guidance.
 
 - [x] ARCH-009 - Invoice idempotent use-case rollout (application + API + worker)
   - Status: DONE
@@ -118,9 +121,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-009-invoice-idempotent-rollout`
   - PR: `#53`
   - Merge SHA: `591315941c9a0944cb353279ce651888462e2c6b`
-  - Notes: Delivered async invoice enqueue/status API, application idempotent enqueue/process/status use-cases, worker processing loop, and full coverage across application/API/worker.
-  - Residual risks: In-memory queue/idempotency storage is non-durable and must be replaced by persistent infrastructure in ARCH-010.
-
+  - Notes: Delivered async invoice enqueue/status API, application idempotent enqueue/process/status use-cases, worker processing loop, and coverage across application/API/worker.
 
 - [x] ARCH-010 - Invoice async infrastructure hardening (durable queue, retries, observability)
   - Status: DONE
@@ -128,7 +129,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-010-invoice-infra-hardening`
   - PR: `#56`
   - Merge SHA: `487c7bf621cc8f657cd0911c0255c7a86007a577`
-  - Notes: Replace in-memory invoice async infrastructure with durable queue/store, add retry/backoff + dead-letter strategy, and observability while preserving ARCH-009 public contracts.
+  - Notes: Replaced in-memory invoice async infrastructure with durable queue/store, retry/backoff, dead-letter handling, and observability.
 
 - [x] ARCH-011 - Invoice async operational readiness (observability + replay controls)
   - Status: DONE
@@ -136,7 +137,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-011-invoice-ops-readiness`
   - PR: `#59`
   - Merge SHA: `e58acbb87aba2eb334bf99d3f2d77d84c364434f`
-  - Notes: Add operational observability, replay safeguards, and runbook-level guidance for async invoice flow without changing ARCH-009/010 API contracts.
+  - Notes: Added operational observability, replay safeguards, and runbook-level guidance for async invoice flow.
 
 - [x] ARCH-012 - Schema-first contracts, unified time policy, and boundary dedup polish
   - Status: DONE
@@ -144,7 +145,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-012-schema-time-boundaries`
   - PR: `#65`
   - Merge SHA: `ea6db9a73ac59e7fa2575808ae45d6f10c1701fb`
-  - Notes: Enforce schema-first contracts (Zod as source of truth), unify Luxon datetime policy, and remove duplicated boundary orchestration while preserving API behavior.
+  - Notes: Enforced schema-first contracts, unified Luxon datetime policy, and removed duplicated boundary orchestration while preserving API behaviour.
 
 - [x] ARCH-018 - Schema-first boundaries and OpenAPI generation
   - Status: DONE
@@ -152,7 +153,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-018-schema-boundaries`
   - PR: `#89`
   - Merge SHA: `4c384d0`
-  - Notes: Hardened schema-first request boundaries, added OpenAPI generation/validation scripts, and versioned OpenAPI artifact checks. Follow-ups: `#92` migrated validation to Redocly and enriched generated OAS metadata; `#93` removed the legacy swagger-parser validator script.
+  - Notes: Hardened schema-first request boundaries, added OpenAPI generation/validation scripts, and versioned OpenAPI artefact checks.
 
 - [x] ARCH-019 - Error model v2 and i18n-ready envelope
   - Status: DONE
@@ -160,7 +161,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-019-error-model-v2-i18n-envelope`
   - PR: `#95`
   - Merge SHA: `e56fc1d`
-  - Notes: Introduced Error Model v2 with `messageKey`/`messageParams`, preserved backward compatibility (`message` + `code`), added structured validation details (`details.issues[]`), and expanded en-US error catalog for critical paths.
+  - Notes: Introduced Error Model v2 with `messageKey`/`messageParams`, preserved backward compatibility, and expanded structured validation detail coverage.
 
 - [x] ARCH-020 - Full operational observability baseline
   - Status: DONE
@@ -168,7 +169,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-020-observability-baseline`
   - PR: `#97`
   - Merge SHA: `6f1f833`
-  - Notes: Delivered observability baseline with structured logs, worker-cycle metrics/latency events, and coverage for observability behavior.
+  - Notes: Delivered structured logs, worker-cycle metrics, latency events, and observability behaviour coverage.
 
 - [x] ARCH-021 - CI/CD quality and security gates
   - Status: DONE
@@ -176,15 +177,15 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `chore/arch-021-ci-security-gates`
   - PR: `#90`
   - Merge SHA: `b007968`
-  - Notes: Added CI quality/security workflows, enforced OpenAPI drift checks, enabled Postgres integration gates, and aligned main branch protection with required checks.
+  - Notes: Added CI quality/security workflows, enforced OpenAPI drift checks, enabled Postgres integration gates, and aligned branch protection expectations.
 
-- [x] ARCH-022 - Performance, resilience, and readiness finalization
+- [x] ARCH-022 - Performance, resilience, and readiness finalisation
   - Status: DONE
   - Issue: `#79`
   - Branch: `chore/arch-022-readiness-finalization`
   - PR: `#99`
   - Merge SHA: `fb43b20`
-  - Notes: Finalized readiness baseline with SLI/SLO targets, alert/runbook guidance, and API startup fail-fast runtime validation.
+  - Notes: Finalised readiness baseline with SLI/SLO targets, alert/runbook guidance, and API startup fail-fast validation.
 
 - [x] ARCH-023 - Postgres persistence regression coverage hardening
   - Status: DONE
@@ -192,7 +193,7 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `feat/arch-023-pg-persistence-regression-tests`
   - PR: `#115`
   - Merge SHA: `e7495526b79c558cead94e05d052c8fb694f79a6`
-  - Notes: Added Postgres integration regression coverage for idempotency begin/replay/conflict/restart flows, invoice job lease/retry/dead-letter guard behavior, and tenant-scoped persistence safety. No ADR change required.
+  - Notes: Added Postgres integration regression coverage for idempotency begin/replay/conflict/restart flows, invoice job lease/retry/dead-letter guards, and tenant-scoped persistence safety.
 
 - [x] ARCH-024 - Durable webhook idempotency and audit persistence
   - Status: DONE
@@ -200,31 +201,121 @@ Deliver structural improvements without blocking feature delivery.
   - Branch: `feat/arch-024-webhook-durable-persistence`
   - PR: `#122`
   - Merge SHA: `8b77832143d1a400f50112a1bb9d95c7963bfe25`
-  - Notes: Replaced process-local webhook dedup with durable Postgres-backed idempotency state, persisted processed/duplicate/rejected webhook audit rows, and hardened PG integration test migrations against concurrent suite startup races. No ADR change required.
+  - Notes: Replaced process-local webhook dedupe with durable Postgres-backed idempotency state, persisted webhook audit rows, and hardened migration/test startup behaviour.
+
+- [x] ARCH-025 - Harden bootstrap and boundary coverage
+  - Status: DONE
+  - Issue: `#142`
+  - Branch: `test/arch-025-bootstrap-boundary-coverage`
+  - PR: `#146`
+  - Merge SHA: `5bd8c975f7d988eee176b69b54e016346468aa9b`
+  - Notes: Strengthened bootstrap, domain, and contract boundary coverage to make architectural seams safer to refactor.
+
+- [x] ARCH-026 - Decompose invoice application orchestration
+  - Status: DONE
+  - Issue: `#143`
+  - Branch: `refactor/arch-026-invoice-application-decomposition`
+  - PR: `#147`
+  - Merge SHA: `29c4086f402bba179ffa8f306df1b250399201cf`
+  - Notes: Split the invoice orchestration hotspot into smaller cohesive modules while preserving the public application surface.
+
+- [x] ARCH-027 - Improve workspace DX and remove build-artefact coupling
+  - Status: DONE
+  - Issue: `#144`
+  - Branch: `chore/arch-027-workspace-dx-build-artifacts`
+  - PR: `#148`
+  - Merge SHA: `579db197b092288eee8e88bc7a93c52242f78fbe`
+  - Notes: Improved workspace test ergonomics, source-based OpenAPI generation, and removed unnecessary reliance on built artefacts.
+
+- [x] ARCH-028 - Establish deployable runtime baseline for API and worker
+  - Status: DONE
+  - Issue: `#145`
+  - Branch: `chore/arch-028-runtime-baseline`
+  - PR: `#149`
+  - Merge SHA: `2303ccdebd6c2da11f7e2323be80f1a4196651c2`
+  - Notes: Added executable API and worker entrypoints, Dockerfiles, health/readiness endpoints, and production-like runtime validation.
+
+- [x] ARCH-029 - Harden runtime security and environment contracts
+  - Status: DONE
+  - Issue: `#150`
+  - Branch: `chore/arch-029-runtime-security-env-contracts`
+  - PR: `#155`
+  - Merge SHA: `3524fa59b9f1172a0b5cd4dee3a51005c551236e`
+  - Notes: Added explicit runtime config validation, safer API request handling, non-root containers, and documented environment contracts.
+
+- [x] ARCH-030 - Add runtime metrics and operational observability stack
+  - Status: DONE
+  - Issue: `#151`
+  - Branch: `feat/arch-030-runtime-metrics-observability`
+  - PR: `#156`
+  - Merge SHA: `ad79c6bf141343fef60df5c28a3aefefd222f471`
+  - Notes: Added Prometheus-style API/worker metrics, structured log metadata, and committed Prometheus/Grafana observability assets.
+
+- [x] ARCH-031 - Add self-hosted deployment baseline and stack smoke validation
+  - Status: DONE
+  - Issue: `#152`
+  - Branch: `chore/arch-031-self-hosted-deployment-baseline`
+  - PR: `#157`
+  - Merge SHA: `50f780fc9528f301eb998966e241de90a94c3e92`
+  - Notes: Added a production-like self-hosted compose stack, health checks, smoke validation, and CI Docker image build coverage.
+
+- [x] ARCH-032 - Add guided demo scenario and seeded billing walkthrough
+  - Status: DONE
+  - Issue: `#153`
+  - Branch: `feat/arch-032-guided-demo-billing-flow`
+  - PR: `#158`
+  - Merge SHA: `d01d1ee6a81de1f73a5b90a959bb57fce2e81ffb`
+  - Notes: Added a reproducible demo seed path, self-hosted walkthrough, and operator-friendly demo documentation.
+
+- [x] ARCH-033 - Harden supply-chain and container security baseline
+  - Status: DONE
+  - Issue: `#154`
+  - Branch: `chore/arch-033-supply-chain-container-security`
+  - PR: `#159`
+  - Merge SHA: `5fad62e446d58802ce80837ef9fe530302856906`
+  - Notes: Added container scanning, SBOM generation, Dependabot automation, and security operations guidance while tightening runtime secret handling.
+
+## Post-Baseline Backlog
+
+- [ ] ARCH-035 - Decompose API server runtime and HTTP host boundary
+  - Status: PLANNED
+  - Issue: `#174`
+  - Notes: Reduce the next runtime hotspot in `apps/api/src/server.ts` without changing public billing behaviour.
+
+- [ ] ARCH-036 - Decompose idempotency and subscription orchestration
+  - Status: PLANNED
+  - Issue: `#175`
+  - Notes: Reduce structural risk in the application layer by decomposing the next two core hotspots.
+
+- [ ] ARCH-037 - Deepen billing catalog, plan-version, and entitlement realism
+  - Status: PLANNED
+  - Issue: `#176`
+  - Notes: Increase product realism after the current structural/documentation refresh is complete.
 
 ## ADR References
 
 - [x] ADR-005 - Domain vs Application boundary
-- [x] ADR-006 - Validation strategy (schema-first, accepted)
-- [x] ADR-007 - Date/time and timezone policy (accepted)
-- [x] ADR-008 - Error and response standardization (accepted)
-- [x] ADR-009 - Generic idempotency strategy (accepted)
-- [x] ADR-010 - i18n foundation with `en_US` baseline (accepted)
-- [x] ADR-011 - Idempotency state machine and concurrency strategy (accepted)
-- [x] ADR-012 - Classes vs functions guideline (accepted)
-- [x] ADR-013 - Async idempotent invoice rollout (accepted)
-- [x] ADR-014 - Durable invoice async infrastructure (accepted)
-- [x] ADR-016 - Schema-first contracts, time policy, and boundary polish (accepted)
+- [x] ADR-006 - Validation strategy (schema-first)
+- [x] ADR-007 - Date/time and timezone policy
+- [x] ADR-008 - Error and response standardisation
+- [x] ADR-009 - Generic idempotency strategy
+- [x] ADR-010 - i18n foundation with `en_US` baseline
+- [x] ADR-011 - Idempotency state machine and concurrency strategy
+- [x] ADR-012 - Classes vs functions guideline
+- [x] ADR-013 - Async idempotent invoice rollout
+- [x] ADR-014 - Durable invoice async infrastructure
+- [x] ADR-015 - Invoice async operational readiness
+- [x] ADR-016 - Schema-first contracts, time policy, and boundary polish
 
 ## Quality Gates (mandatory per PR)
 
-- [ ] `npm run quality:gate`
-- [ ] `DATABASE_URL=postgresql://grantledger_app:grantledger_app@localhost:5432/grantledger_rls npm run test:pg` (or CI evidence)
-- [ ] `Architectural scope respected (no mixed feature work)`
+- [x] `npm run quality:gate`
+- [x] `DATABASE_URL=postgresql://grantledger_app:grantledger_app@localhost:5432/grantledger_rls npm run test:pg` (or CI evidence)
+- [x] Architectural scope respected (no mixed feature work)
 
-## Done Criteria for ARCH-000
+## Done Criteria for ARCH-000 Baseline
 
-- [ ] All child issues completed and merged
-- [ ] ADRs updated with final architectural decisions
-- [ ] Quality gates passed for every child PR
-- [ ] Tracker fully updated with issue/PR links
+- [x] Child issues completed and merged through `ARCH-033`
+- [x] ADRs updated for accepted architectural decisions
+- [x] Quality/security gates enforced across the stream
+- [x] Tracker updated to the completed baseline

--- a/docs/architecture/IMPROVEMENT-ROADMAP.md
+++ b/docs/architecture/IMPROVEMENT-ROADMAP.md
@@ -2,85 +2,108 @@
 
 ## Context
 
-This roadmap tracks architecture hardening as a continuous stream running in parallel with feature delivery.
+This roadmap tracks architecture improvement as a continuous stream that stays grounded in real structural risk, not abstract refactoring for its own sake.
 
 Canonical references:
 
 - Tracker: `docs/architecture/ARCH-TRACKER.md`
 - Guardrails: `docs/architecture/ARCH-GUARDRAILS.md`
+- Health check: `docs/governance/architecture-health-check.md`
 - Boundary decision: `docs/adr/ADR-005-domain-vs-application-boundary.md`
+
+## Current Platform Baseline
+
+The platform baseline is complete through `ARCH-033`.
+
+That baseline now includes:
+
+- schema-first contracts and OpenAPI validation;
+- shared time/error/idempotency foundations;
+- durable webhook and invoice infrastructure in Postgres;
+- executable API and worker runtimes with validated environment contracts;
+- Prometheus-style metrics, structured logs, and Grafana/Prometheus assets;
+- a self-hosted deployment stack with smoke validation;
+- a guided demo path for end-to-end local demonstration;
+- supply-chain and container security automation.
 
 ## Progress Snapshot
 
-- ARCH-001 completed (`#31`)
-- ARCH-002 completed (`#32`)
-- ARCH-003 completed (`#34`, merge `dc7404d`)
-- ARCH-004 completed (`#37`, merge `46e6804`)
-- ARCH-005 completed (`#40`, merge `b72ef69`)
-- ARCH-006 completed (`#43`, merge `0706202`)
-- ARCH-007 completed (`#46`, merge `64e2d3d`)
-- ARCH-008 completed (`#49`, merge `bef4fbc`)
-- ARCH-009 completed (`#53`, merge `5913159`)
-- ARCH-010 completed (`#56`, merge `487c7bf`)
-- ARCH-011 completed (`#59`, merge `e58acbb`)
-- ARCH-012 completed (`#65`, merge `ea6db9a`)
-- ARCH-018 completed (`#89`, `#92`, `#93`; merges `4c384d0`, `3faf3f0`, `9da76c7`)
-- ARCH-021 completed (`#90`, merge `b007968`)
-- ARCH-019 completed (`#95`, merge `e56fc1d`)
-- ARCH-020 completed (`#77`, branch `chore/arch-020-observability-baseline`)
-- ARCH-022 completed (`#99`, merge `fb43b20`)
-- ARCH-023 completed (`#115`, merge `e749552`)
-- ARCH-024 completed (`#122`, merge `8b77832`)
+### Completed baseline waves
 
-## Target Architecture Principles
+- `ARCH-001` to `ARCH-012`
+  - completed core boundary, validation, time, error, idempotency, i18n, and async invoice hardening foundations
+- `ARCH-018`
+  - completed schema-first request boundaries and OpenAPI generation (`#89`, merge `4c384d0`)
+- `ARCH-019`
+  - completed Error Model v2 and i18n-ready envelope (`#95`, merge `e56fc1d`)
+- `ARCH-020`
+  - completed operational observability baseline (`#97`, merge `6f1f833`)
+- `ARCH-021`
+  - completed CI/security quality gates (`#90`, merge `b007968`)
+- `ARCH-022`
+  - completed readiness/performance finalisation (`#99`, merge `fb43b20`)
+- `ARCH-023`
+  - completed Postgres persistence regression coverage hardening (`#115`, merge `e749552`)
+- `ARCH-024`
+  - completed durable webhook idempotency and audit persistence (`#122`, merge `8b77832`)
+- `ARCH-025`
+  - completed bootstrap and boundary coverage hardening (`#146`, merge `5bd8c97`)
+- `ARCH-026`
+  - completed invoice orchestration decomposition (`#147`, merge `29c4086`)
+- `ARCH-027`
+  - completed workspace DX and build-artefact decoupling (`#148`, merge `579db19`)
+- `ARCH-028`
+  - completed deployable API/worker runtime baseline (`#149`, merge `2303ccd`)
+- `ARCH-029`
+  - completed runtime security and environment contracts (`#155`, merge `3524fa5`)
+- `ARCH-030`
+  - completed runtime metrics and operational observability stack (`#156`, merge `ad79c6b`)
+- `ARCH-031`
+  - completed self-hosted deployment baseline and smoke validation (`#157`, merge `50f780f`)
+- `ARCH-032`
+  - completed guided demo scenario and seeded billing walkthrough (`#158`, merge `d01d1ee`)
+- `ARCH-033`
+  - completed supply-chain and container security baseline (`#159`, merge `5fad62e`)
 
-- Domain contains pure business invariants and state transitions.
-- Application contains use-case orchestration, ports, idempotency flow, and audit coordination.
-- API/infra contains request parsing, dependency wiring, transport mapping, and adapters.
-- External SDKs remain isolated at infrastructure edges.
-- Canonical contracts/events are explicit and versioned.
+## Next Prioritised Sequence
 
-## Current Prioritized Sequence
+### ARCH-035 - Decompose API server runtime and HTTP host boundary
 
-- ARCH stream hardening baseline completed through ARCH-024.
-- New architecture increments should open new ARCH issues from concrete risks.
+- Issue: `#174`
+- Why next:
+  - `apps/api/src/server.ts` is now the clearest runtime hotspot;
+  - decomposing it reduces future coupling in request parsing, metrics, health/readiness, and host assembly.
+
+### ARCH-036 - Decompose idempotency and subscription orchestration
+
+- Issue: `#175`
+- Why after `ARCH-035`:
+  - idempotency and subscription remain central application hotspots;
+  - they deserve the same stable-facade, incremental decomposition approach used successfully in invoice orchestration.
+
+### ARCH-037 - Deepen billing catalog, plan-version, and entitlement realism
+
+- Issue: `#176`
+- Why after the refactors:
+  - the next major leverage after platform hardening is stronger product realism;
+  - billing depth should be expanded on top of a cleaner application/runtime structure, not in parallel with hotspot cleanup.
 
 ## Delivery Strategy
 
 - One architecture issue per PR.
 - Keep architecture PRs focused and reviewable.
-- No unrelated business scope mixed into ARCH PRs.
+- Do not mix unrelated product scope into ARCH waves.
+- Preserve a stable public surface unless a change is explicitly intentional and documented.
 - Required gates per PR:
   - `npm run quality:gate`
-  - `DATABASE_URL=postgresql://grantledger:grantledger@localhost:5432/grantledger npm run test:pg` (CI mandatory)
-  - Security baseline checks (`Dependency Audit`, `CodeQL`)
+  - `DATABASE_URL='postgresql://grantledger_app:grantledger_app@localhost:5432/grantledger_rls' npm run test:pg`
+  - CI/security evidence for the relevant workflows
 
-## Mandatory Governance Workflow (Always)
+## Success Criteria
 
-### Start of issue
+The roadmap is succeeding when:
 
-- Mark issue as `IN_PROGRESS` in `ARCH-TRACKER.md`.
-- Register issue link, branch name, and planned scope.
-- Update roadmap focus/dependencies.
-- Create ADR draft when new architectural decision is needed.
-
-### End of issue (before merge)
-
-- Mark issue as `DONE` in `ARCH-TRACKER.md`.
-- Register PR link and merged SHA.
-- Update roadmap next step and residual risks.
-- Finalize ADR changes or explicitly register `No ADR change required`.
-
-## Success Criteria for ARCH Stream
-
-- No core business logic concentrated in monolithic modules.
-- Layer boundaries are clear and reviewable.
-- Validation, time policy, and error mapping are standardized.
-- Idempotency orchestration is generic and reusable.
-- Governance docs stay synchronized with code and PR lifecycle.
-
-## Next execution focus: Architecture Backlog Refresh
-
-- Monitor current baselines (CI/security/OpenAPI/observability) for regressions.
-- Open a new ARCH issue only when a clear structural gap is identified.
-- Preserve error-model, schema-first, and runtime fail-fast guardrails.
+- governance documents accurately reflect delivered architecture;
+- the next structural hotspots become easier to navigate and safer to change;
+- product depth increases without eroding the current platform baseline;
+- new ARCH waves are opened because of concrete leverage, not inertia.

--- a/docs/governance/architecture-health-check.md
+++ b/docs/governance/architecture-health-check.md
@@ -1,19 +1,52 @@
-# Architecture Health Check (Monthly)
+# Architecture Health Check
 
 ## Purpose
-Keep architecture baselines healthy after ARCH-024 without unnecessary process overhead.
+
+Keep the post-`ARCH-033` platform baseline healthy without creating process for its own sake.
 
 ## Cadence
-- Monthly review (or after major incident)
+
+- monthly review; or
+- immediate review after a material production-like incident, failed smoke path, or broken architecture/security baseline.
+
+## Inputs
+
+Review the following artefacts before deciding whether a new ARCH issue is necessary:
+
+- `README.md`
+- `docs/architecture/ARCH-TRACKER.md`
+- `docs/architecture/IMPROVEMENT-ROADMAP.md`
+- `docs/governance/security-operations.md`
+- `deploy/self-hosted/README.md`
+- current CI/security workflow status
 
 ## Checklist
-1. CI/security/OpenAPI gates still green and enforced
-2. Error model and schema-first boundaries unchanged
-3. Runtime fail-fast guards still active
-4. Observability signals (latency/failure/queue depth) stable
-5. Decide: open new ARCH issue only if a concrete structural risk exists
 
-## Output
-- Short decision note in a GitHub issue:
-  - no action required, or
-  - create a new ARCH-* issue with scope and risk justification
+1. Runtime security and environment contracts still reflect the actual API and worker startup behaviour.
+2. Schema-first boundaries, error model conventions, and idempotency guarantees remain intact.
+3. Health, readiness, and metrics endpoints still behave as documented.
+4. Self-hosted smoke validation still proves the stack can boot end to end.
+5. Observability assets (Prometheus/Grafana) still match the current runtime surface.
+6. Demo flow documentation still matches the actual seeded walkthrough.
+7. Supply-chain security automation (Dependency Audit, CodeQL, Trivy, SBOM generation) is still green and relevant.
+8. Governance documents are aligned with the current `main` baseline rather than an earlier checkpoint.
+9. The next proposed ARCH wave is justified by a concrete hotspot, structural risk, or leverage opportunity.
+
+## Decision Outcomes
+
+Record a short decision note in a GitHub issue or PR thread:
+
+- `No action required`
+  - the current platform baseline is healthy
+- `Open new ARCH issue`
+  - a concrete structural gap or risk justifies a scoped new wave
+- `Refresh governance/docs`
+  - code is healthy, but tracker/roadmap/README/health-check drift needs correction
+
+## Current Review Posture
+
+As of the `ARCH-033` baseline:
+
+- the platform runtime, observability, self-hosted, demo, and security foundations are in place;
+- the next likely ARCH candidates are documentation/governance sync and the remaining application/runtime hotspots;
+- new architecture work should remain issue-driven and explicitly justified.


### PR DESCRIPTION
## Summary
- sync the architecture tracker through the completed `ARCH-033` baseline
- refresh the improvement roadmap so it reflects the current platform state and the next real hotspots
- update the architecture health check to align with the runtime, observability, self-hosted, demo, and security baselines now present on `main`

## Validation
- `npm run quality:gate`
- verified remaining README baseline references already reflect `ARCH-033`
- reviewed tracker, roadmap, and health-check links/paths against the current repository layout

Closes #173
