### PR TITLE
fix(container): patch runtime OpenSSL packages

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -31,6 +31,8 @@ FROM node:22.22.3-alpine3.23@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b44
 WORKDIR /app
 ENV NODE_ENV=production
 
+RUN apk add --no-cache --upgrade "libcrypto3>=3.5.7-r0" "libssl3>=3.5.7-r0"
+
 COPY --from=build /app/package.json ./package.json
 COPY --from=production-deps /app/node_modules ./node_modules
 COPY --from=build /app/apps/api/package.json ./apps/api/package.json

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -29,6 +29,8 @@ FROM node:22.22.3-alpine3.23@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b44
 WORKDIR /app
 ENV NODE_ENV=production
 
+RUN apk add --no-cache --upgrade "libcrypto3>=3.5.7-r0" "libssl3>=3.5.7-r0"
+
 COPY --from=build /app/package.json ./package.json
 COPY --from=production-deps /app/node_modules ./node_modules
 COPY --from=build /app/apps/worker/package.json ./apps/worker/package.json


### PR DESCRIPTION
## Objective

Restore the blocking container security gates after Trivy identified CVE-2026-45447 in the pinned Node Alpine runtime images.

## Root cause

The pinned `node:22.22.3-alpine3.23` digest contains `libcrypto3` and `libssl3` 3.5.6-r0. Trivy 0.71.0 now reports the OpenSSL PKCS7_verify heap use-after-free as fixable HIGH severity, with 3.5.7-r0 as the fixed version. The newly published Node Alpine 3.24 image was evaluated but contains the same vulnerable OpenSSL version.

## Change

- Preserve the existing audited Node digest and service-minimized runtime layout.
- Upgrade only runtime `libcrypto3` and `libssl3`, enforcing a minimum patched version of 3.5.7-r0.
- Leave build stages, application dependencies, workflows, API contracts, and runtime assertions unchanged.

## Validation

- `npm ci`
- `npm ls picomatch --all`
- `npm audit --omit=dev --audit-level=high` (0 production findings)
- `npm run quality:gate` (117 passed, 13 skipped)
- isolated PostgreSQL migrations and `npm run test:pg` (13 passed)
- API and worker image builds for `linux/amd64`
- external runtime inspection: Node works, non-root user, OpenSSL 3.5.7-r0, npm/npx/dev tools absent, service boundaries preserved
- `npm run selfhost:smoke` with explicit teardown
- Trivy 0.71.0 against both final images with `HIGH,CRITICAL`, `os,library`, `ignore-unfixed`, `exit-code 1`: 0 findings

## Risk and compatibility

No HTTP contracts, application behavior, lockfiles, workflows, or dependency manifests are changed. The runtime package floor intentionally allows later Alpine security patch revisions while failing the build if the minimum fixed OpenSSL package is unavailable.